### PR TITLE
feat: 혼잡도 데이터 자동 갱신 기능 추가

### DIFF
--- a/src/hooks/useCongestionMarkers.ts
+++ b/src/hooks/useCongestionMarkers.ts
@@ -1,15 +1,24 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { fetchAllCongestion } from '../api/congestionApi';
 import { LOCATION_MAP } from '../data/locations';
 import { CONGESTION_LEVEL_MAP } from '../types/congestion';
 import type { PlaceMarker } from '../types/congestion';
 
+const POLLING_INTERVAL = 60_000;
+
 export const useCongestionMarkers = (): PlaceMarker[] => {
   const [markers, setMarkers] = useState<PlaceMarker[]>([]);
+  const prevPopulationTimeRef = useRef<string | null>(null);
 
-  useEffect(() => {
+  const load = useCallback(() => {
     fetchAllCongestion()
       .then((data) => {
+        if (data.length === 0) return;
+
+        const latestTime = data[0].populationTime;
+        if (latestTime === prevPopulationTimeRef.current) return;
+        prevPopulationTimeRef.current = latestTime;
+
         const result: PlaceMarker[] = [];
         for (const item of data) {
           const location = LOCATION_MAP.get(item.areaCode);
@@ -38,6 +47,12 @@ export const useCongestionMarkers = (): PlaceMarker[] => {
         console.error('[useCongestionMarkers] 혼잡도 데이터 로드 실패:', err);
       });
   }, []);
+
+  useEffect(() => {
+    load();
+    const interval = setInterval(load, POLLING_INTERVAL);
+    return () => clearInterval(interval);
+  }, [load]);
 
   return markers;
 };

--- a/src/hooks/useCongestionMarkers.ts
+++ b/src/hooks/useCongestionMarkers.ts
@@ -17,7 +17,6 @@ export const useCongestionMarkers = (): PlaceMarker[] => {
 
         const latestTime = data[0].populationTime;
         if (latestTime === prevPopulationTimeRef.current) return;
-        prevPopulationTimeRef.current = latestTime;
 
         const result: PlaceMarker[] = [];
         for (const item of data) {
@@ -42,6 +41,7 @@ export const useCongestionMarkers = (): PlaceMarker[] => {
           });
         }
         setMarkers(result);
+        prevPopulationTimeRef.current = latestTime;
       })
       .catch((err) => {
         console.error('[useCongestionMarkers] 혼잡도 데이터 로드 실패:', err);


### PR DESCRIPTION
## 관련 이슈
Closes #14 

백엔드는 5분마다 혼잡도 데이터를 갱신하지만, 프론트는 최초 1회만 fetch하여 사용자 화면에 반영되지 않는 문제를 해결했습니다.

## 변경 사항
- 1분마다 /api/congestion 재호출하는 폴링 추가
- populationTime 비교로 실제 데이터 변경 시에만 상태 업데이트(불필요한 리렌더 방지)
- 컴포넌트 언마운트 시 clearInterval로 인터벌 정리