### PR TITLE
fix: 모바일 뷰에서 카테고리 필터 overflow로 인한 헤더 잘림 수정

### DIFF
--- a/src/components/filter/CategoryFilter.tsx
+++ b/src/components/filter/CategoryFilter.tsx
@@ -15,7 +15,8 @@ interface CategoryFilterProps {
 
 const CategoryFilter = ({ selected, onSelect }: CategoryFilterProps) => {
   return (
-    <div className="absolute top-4 left-1/2 -translate-x-1/2 z-10 flex items-center gap-2 bg-white rounded-full px-3 py-2 shadow-md">
+    <div className="absolute top-4 inset-x-4 z-10 flex justify-center">
+      <div className="flex items-center gap-2 bg-white rounded-full px-3 py-2 shadow-md overflow-x-auto max-w-full w-fit">
       {CATEGORIES.map(({ id, label, Icon }) => (
         <button
           key={id}
@@ -30,6 +31,7 @@ const CategoryFilter = ({ selected, onSelect }: CategoryFilterProps) => {
           <span>{label}</span>
         </button>
       ))}
+      </div>
     </div>
   );
 };

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -11,14 +11,10 @@ const HomePage = () => {
   return (
     <div className="flex flex-col w-full h-dvh">
       <Header />
-      <div className="relative flex-1">
+      <div className="relative flex-1 overflow-hidden">
         <KakaoMap selectedCategory={selectedCategory} />
         <CategoryFilter selected={selectedCategory} onSelect={setSelectedCategory} />
-        <MapControls
-          onZoomIn={() => {}}
-          onZoomOut={() => {}}
-          onLocate={() => {}}
-        />
+        <MapControls onZoomIn={() => {}} onZoomOut={() => {}} onLocate={() => {}} />
         <CongestionLegend />
       </div>
     </div>


### PR DESCRIPTION
## 변경 사항
- HomePage: 지도 컨테이너에 `overflow-hidden` 추가
- CategoryFilter: 포지셔닝 방식을 `inset-x-4 + w-fit + justify-center`로 변경

## 버그 원인
카테고리 필터가 `left-1/2 -translate-x-1/2`로 중앙 정렬될 때,
모바일 화면에서 버튼 5개의 합산 너비가 뷰포트를 초과해 페이지 전체 너비가 늘어남.
sticky 헤더가 늘어난 페이지 너비 기준으로 렌더링되어 양쪽이 잘려 보이는 문제 발생.

## 해결
1. overflow-hidden으로 페이지 너비가 늘어나는 것 차단
2. 필터 구조 변경으로 필터가 뷰포트를 벗어나지 않도록 수정
