### PR TITLE
feat: CongestionMarker 팝업 개선 및 장소 상세 페이지 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:remote": "API_TARGET=https://api.goseoul.today vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "format": "prettier --write src/**/*.{ts,tsx}",

--- a/src/api/congestionApi.ts
+++ b/src/api/congestionApi.ts
@@ -6,3 +6,8 @@ export const fetchAllCongestion = async (): Promise<CongestionData[]> => {
   const res = await instance.get<ApiResponse<CongestionData[]>>('/api/congestion');
   return res.data.data;
 };
+
+export const fetchCongestionByAreaCode = async (areaCode: string): Promise<CongestionData> => {
+  const res = await instance.get<ApiResponse<CongestionData>>(`/api/congestion/${areaCode}`);
+  return res.data.data;
+};

--- a/src/components/map/CongestionMarker.tsx
+++ b/src/components/map/CongestionMarker.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { CustomOverlayMap } from 'react-kakao-maps-sdk';
-import { MapPin } from 'lucide-react';
+import { MapPin, X } from 'lucide-react';
 import { CONGESTION_COLORS, CONGESTION_LABELS } from '../../types/congestion';
+import { CATEGORY_LABELS } from '../../data/categories';
 import type { PlaceMarker } from '../../types/congestion';
 
 interface CongestionMarkerProps {
@@ -14,44 +16,107 @@ const BASE_SIZE = 32;
 
 const CongestionMarker = ({ marker, level }: CongestionMarkerProps) => {
   const [isOpen, setIsOpen] = useState(false);
+  const navigate = useNavigate();
   const color = CONGESTION_COLORS[marker.congestionLevel];
   const position = { lat: marker.latitude, lng: marker.longitude };
   const scale = Math.max(0.5, Math.min(2.5, 1 + (BASE_LEVEL - level) * 0.2));
   const size = Math.round(BASE_SIZE * scale);
+  const avgPeople = Math.round((marker.minPeopleCount + marker.maxPeopleCount) / 2);
 
   return (
     <>
-      <CustomOverlayMap position={position} yAnchor={1}>
-        <div
-          className="cursor-pointer flex flex-col items-center hover:scale-110 active:scale-95 transition-transform"
-          style={{ filter: 'drop-shadow(0 3px 8px rgba(0,0,0,0.3))' }}
-          onClick={() => setIsOpen((prev) => !prev)}
-        >
+      {!isOpen && (
+        <CustomOverlayMap position={position} yAnchor={1}>
           <div
-            className="flex items-center justify-center rounded-full border-[3px] border-white"
-            style={{ backgroundColor: color, width: size * 0.85, height: size * 0.85 }}
+            className="cursor-pointer flex flex-col items-center hover:scale-110 active:scale-95 transition-transform"
+            style={{ filter: 'drop-shadow(0 3px 8px rgba(0,0,0,0.3))' }}
+            onClick={() => setIsOpen(true)}
           >
-            <MapPin size={size * 0.38} color="white" strokeWidth={2.5} />
+            <div
+              className="flex items-center justify-center rounded-full border-[3px] border-white"
+              style={{ backgroundColor: color, width: size * 0.85, height: size * 0.85 }}
+            >
+              <MapPin size={size * 0.38} color="white" strokeWidth={2.5} />
+            </div>
+            <div
+              className="-mt-px"
+              style={{
+                width: 0,
+                height: 0,
+                borderLeft: `${size * 0.15}px solid transparent`,
+                borderRight: `${size * 0.15}px solid transparent`,
+                borderTop: `${size * 0.35}px solid ${color}`,
+              }}
+            />
           </div>
-          <div
-            className="-mt-px"
-            style={{
-              width: 0,
-              height: 0,
-              borderLeft: `${size * 0.15}px solid transparent`,
-              borderRight: `${size * 0.15}px solid transparent`,
-              borderTop: `${size * 0.35}px solid ${color}`,
-            }}
-          />
-        </div>
-      </CustomOverlayMap>
+        </CustomOverlayMap>
+      )}
+
       {isOpen && (
-        <CustomOverlayMap position={position} yAnchor={1.6}>
-          <div className="bg-white rounded-xl px-3 py-2 shadow-lg border border-gray-100 text-sm whitespace-nowrap">
-            <p className="font-semibold text-gray-800">{marker.name}</p>
-            <p className="text-xs text-gray-500 mt-0.5">
-              혼잡도: {CONGESTION_LABELS[marker.congestionLevel]}
-            </p>
+        <CustomOverlayMap position={position} yAnchor={1} zIndex={10}>
+          <div
+            className="flex flex-col items-center"
+            style={{ filter: 'drop-shadow(0 4px 16px rgba(0,0,0,0.15))' }}
+          >
+            <div className="bg-white rounded-2xl p-3 w-52">
+              <div className="flex items-start justify-between mb-1.5">
+                <p className="font-bold text-gray-900 text-sm">{marker.name}</p>
+                <button
+                  onClick={() => setIsOpen(false)}
+                  className="cursor-pointer text-gray-400 hover:text-gray-600 ml-2 shrink-0"
+                >
+                  <X size={14} />
+                </button>
+              </div>
+
+              <div className="flex gap-1 mb-2">
+                <span className="text-xs text-gray-500 bg-gray-100 rounded-full px-2 py-0.5">
+                  {CATEGORY_LABELS[marker.category] ?? marker.category}
+                </span>
+              </div>
+
+              <div className="space-y-1.5 mb-3">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-gray-600">혼잡도</span>
+                  <span
+                    className="text-xs font-semibold px-2 py-0.5 rounded-full text-white"
+                    style={{ backgroundColor: color }}
+                  >
+                    {CONGESTION_LABELS[marker.congestionLevel]}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-gray-600">현재 인원</span>
+                  <span className="text-sm font-bold text-gray-900">
+                    {avgPeople.toLocaleString()}명
+                  </span>
+                </div>
+              </div>
+
+              <div className="flex flex-col gap-1.5">
+                <button
+                  disabled
+                  className="w-full py-2 rounded-xl bg-gray-100 text-gray-400 text-xs font-semibold cursor-not-allowed"
+                >
+                  대체지역 추천 (준비 중)
+                </button>
+                <button
+                  onClick={() => navigate(`/place/${marker.areaCode}`, { state: { marker } })}
+                  className="cursor-pointer w-full py-2 rounded-xl bg-blue-500 hover:bg-blue-600 text-white text-xs font-semibold transition-colors"
+                >
+                  상세 정보 보기
+                </button>
+              </div>
+            </div>
+            <div
+              style={{
+                width: 0,
+                height: 0,
+                borderLeft: '10px solid transparent',
+                borderRight: '10px solid transparent',
+                borderTop: '10px solid white',
+              }}
+            />
           </div>
         </CustomOverlayMap>
       )}

--- a/src/data/categories.ts
+++ b/src/data/categories.ts
@@ -1,0 +1,6 @@
+export const CATEGORY_LABELS: Record<string, string> = {
+  cafe: '#카페',
+  shopping: '#쇼핑',
+  park: '#공원',
+  culture: '#문화',
+};

--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -11,12 +11,13 @@ import type { CongestionData, PlaceMarker } from '../types/congestion';
 const DetailPage = () => {
   const { placeId } = useParams<{ placeId: string }>();
   const navigate = useNavigate();
-  const { state } = useLocation() as { state: { marker?: PlaceMarker } | null };
+  const { state } = useLocation();
+  const locationState = state as { marker?: PlaceMarker } | null;
   const [data, setData] = useState<CongestionData | null>(null);
-  const [loading, setLoading] = useState(!state?.marker);
+  const [loading, setLoading] = useState(!locationState?.marker);
 
   const placeInfo = placeId ? LOCATION_MAP.get(placeId) : null;
-  const hasMarkerState = !!state?.marker;
+  const hasMarkerState = !!locationState?.marker;
 
   useEffect(() => {
     if (!placeId || hasMarkerState) return;
@@ -26,7 +27,7 @@ const DetailPage = () => {
       .finally(() => setLoading(false));
   }, [placeId, hasMarkerState]);
 
-  const marker = state?.marker ?? null;
+  const marker = locationState?.marker ?? null;
   const congestionLevel = marker
     ? marker.congestionLevel
     : data
@@ -68,7 +69,7 @@ const DetailPage = () => {
                 <h1 className="text-2xl font-bold text-gray-900">{placeInfo.name}</h1>
                 <div className="flex gap-1.5 mt-2">
                   <span className="text-xs text-gray-500 bg-gray-100 rounded-full px-2.5 py-1">
-                    {CATEGORY_LABELS[placeInfo.category]}
+                    {CATEGORY_LABELS[placeInfo.category] ?? placeInfo.category}
                   </span>
                 </div>
               </div>

--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -1,5 +1,114 @@
+import { useEffect, useState } from 'react';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
+import { ArrowLeft, Users, Clock } from 'lucide-react';
+import Header from '../components/layout/Header';
+import { fetchCongestionByAreaCode } from '../api/congestionApi';
+import { LOCATION_MAP } from '../data/locations';
+import { CATEGORY_LABELS } from '../data/categories';
+import { CONGESTION_COLORS, CONGESTION_LABELS, CONGESTION_LEVEL_MAP } from '../types/congestion';
+import type { CongestionData, PlaceMarker } from '../types/congestion';
+
 const DetailPage = () => {
-  return <div>DetailPage</div>;
+  const { placeId } = useParams<{ placeId: string }>();
+  const navigate = useNavigate();
+  const { state } = useLocation() as { state: { marker?: PlaceMarker } | null };
+  const [data, setData] = useState<CongestionData | null>(null);
+  const [loading, setLoading] = useState(!state?.marker);
+
+  const placeInfo = placeId ? LOCATION_MAP.get(placeId) : null;
+  const hasMarkerState = !!state?.marker;
+
+  useEffect(() => {
+    if (!placeId || hasMarkerState) return;
+    fetchCongestionByAreaCode(placeId)
+      .then(setData)
+      .catch(() => setData(null))
+      .finally(() => setLoading(false));
+  }, [placeId, hasMarkerState]);
+
+  const marker = state?.marker ?? null;
+  const congestionLevel = marker
+    ? marker.congestionLevel
+    : data
+      ? CONGESTION_LEVEL_MAP[data.congestionLevel]
+      : null;
+  const color = congestionLevel ? CONGESTION_COLORS[congestionLevel] : '#9ca3af';
+  const avgPeople = marker
+    ? Math.round((marker.minPeopleCount + marker.maxPeopleCount) / 2)
+    : data
+      ? Math.round((data.minPeopleCount + data.maxPeopleCount) / 2)
+      : 0;
+  const populationTime = marker?.populationTime ?? data?.populationTime ?? '';
+  const congestionMessage = marker?.congestionMessage ?? data?.congestionMessage ?? '';
+
+  return (
+    <div className="flex flex-col w-full min-h-dvh bg-gray-50">
+      <Header />
+      <div className="max-w-5xl mx-auto w-full px-6 py-6">
+        <button
+          onClick={() => navigate('/')}
+          className="cursor-pointer flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-800 mb-6 transition-colors"
+        >
+          <ArrowLeft size={16} />
+          Back to Map
+        </button>
+
+        {loading && <div className="bg-white rounded-2xl p-6 shadow-sm animate-pulse h-44" />}
+
+        {!loading && ((!marker && !data) || !placeInfo) && (
+          <div className="bg-white rounded-2xl p-6 shadow-sm text-center text-gray-400">
+            장소 정보를 불러올 수 없어요.
+          </div>
+        )}
+
+        {!loading && (marker || data) && placeInfo && congestionLevel && (
+          <div className="bg-white rounded-2xl p-6 shadow-sm">
+            <div className="flex items-start justify-between">
+              <div>
+                <h1 className="text-2xl font-bold text-gray-900">{placeInfo.name}</h1>
+                <div className="flex gap-1.5 mt-2">
+                  <span className="text-xs text-gray-500 bg-gray-100 rounded-full px-2.5 py-1">
+                    {CATEGORY_LABELS[placeInfo.category]}
+                  </span>
+                </div>
+              </div>
+              <span
+                className="text-sm font-bold px-3 py-1.5 rounded-full text-white mt-1 shrink-0"
+                style={{ backgroundColor: color }}
+              >
+                {CONGESTION_LABELS[congestionLevel]}
+              </span>
+            </div>
+
+            {congestionMessage && (
+              <p className="mt-4 text-sm text-gray-600 leading-relaxed">{congestionMessage}</p>
+            )}
+
+            <div className="flex gap-8 mt-6">
+              <div className="flex items-center gap-3">
+                <div className="w-10 h-10 bg-blue-50 rounded-xl flex items-center justify-center">
+                  <Users size={18} className="text-blue-500" />
+                </div>
+                <div>
+                  <p className="text-xs text-gray-400">Current Visitors</p>
+                  <p className="text-xl font-bold text-gray-900">{avgPeople.toLocaleString()}</p>
+                </div>
+              </div>
+              <div className="flex items-center gap-3">
+                <div className="w-10 h-10 bg-purple-50 rounded-xl flex items-center justify-center">
+                  <Clock size={18} className="text-purple-500" />
+                </div>
+                <div>
+                  <p className="text-xs text-gray-400">Updated</p>
+                  <p className="text-sm font-medium text-gray-900">{populationTime}</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
 };
 
 export default DetailPage;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:8080',
+        target: process.env.API_TARGET ?? 'http://localhost:8080',
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## 관련 이슈
Closes #20

## 작업 내용

마커 팝업 UI를 개선하고, 팝업에서 이동하는 장소 상세 페이지를 구현했습니다.

**혼잡도 마커 팝업 개선**
- 장소명만 표시하던 팝업을 카테고리, 혼잡도, 현재 인원을 포함한 정보 카드로 교체
- 팝업 끝점과 마커 핀 끝점이 같은 좌표를 가리키도록 정렬 (CustomOverlayMap 조건부 마운트로 앵커 캐싱 문제 해결)
- 팝업이 다른 마커 위에 항상 표시되도록 zIndex 적용
- 대체지역 추천 버튼 비활성화 처리 (기능 미구현)

**장소 상세 페이지 구현 (`/place/:placeId`)**
- 마커 팝업에서 router state로 데이터 전달 → 상세 페이지 진입 시 API 재호출 없이 즉시 렌더링
- 직접 URL 접근 시 `/api/congestion/:areaCode` 호출로 fallback
- 장소명, 카테고리, 혼잡도, 혼잡도 메시지, 현재 인원, 업데이트 시각 표시

**기타**
- 카테고리 레이블 상수를 `data/categories.ts`로 분리(CongestionMarker, DetailPage 중복 제거)
- `dev:remote` 스크립트 추가(로컬 백엔드 없이 원격 API 대상으로 개발 가능)