### PR TITLE
feat: 홈 화면 혼잡도 TOP3 드래그 오버레이 카드 구현

### DIFF
--- a/src/api/congestionApi.ts
+++ b/src/api/congestionApi.ts
@@ -1,6 +1,6 @@
 import instance from './instance';
 import type { ApiResponse } from '../types/api';
-import type { CongestionData } from '../types/congestion';
+import type { CongestionData, CongestionRankingResponse } from '../types/congestion';
 
 export const fetchAllCongestion = async (): Promise<CongestionData[]> => {
   const res = await instance.get<ApiResponse<CongestionData[]>>('/api/congestion');
@@ -9,5 +9,27 @@ export const fetchAllCongestion = async (): Promise<CongestionData[]> => {
 
 export const fetchCongestionByAreaCode = async (areaCode: string): Promise<CongestionData> => {
   const res = await instance.get<ApiResponse<CongestionData>>(`/api/congestion/${areaCode}`);
+  return res.data.data;
+};
+
+export const fetchBusiestRanking = async (
+  limit = 10,
+  signal?: AbortSignal,
+): Promise<CongestionRankingResponse> => {
+  const res = await instance.get<ApiResponse<CongestionRankingResponse>>(
+    '/api/congestion/analysis/ranking/busiest',
+    { params: { limit }, signal },
+  );
+  return res.data.data;
+};
+
+export const fetchRelaxedRanking = async (
+  limit = 10,
+  signal?: AbortSignal,
+): Promise<CongestionRankingResponse> => {
+  const res = await instance.get<ApiResponse<CongestionRankingResponse>>(
+    '/api/congestion/analysis/ranking/relaxed',
+    { params: { limit }, signal },
+  );
   return res.data.data;
 };

--- a/src/components/congestion/CongestionRankCard.tsx
+++ b/src/components/congestion/CongestionRankCard.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { TrendingUp, TrendingDown, ArrowRight } from 'lucide-react';
+import { fetchBusiestRanking, fetchRelaxedRanking } from '../../api/congestionApi';
+import { CONGESTION_LEVEL_MAP, CONGESTION_COLORS, CONGESTION_LABELS } from '../../types/congestion';
+import { useDraggable } from '../../hooks/useDraggable';
+import type { RankingEntry } from '../../types/congestion';
+
+interface Props {
+  type: 'busiest' | 'relaxed';
+  initialRatio: { x: number; y: number };
+}
+
+const CongestionRankCard = ({ type, initialRatio }: Props) => {
+  const navigate = useNavigate();
+  const [entries, setEntries] = useState<RankingEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const { ref, position, scale, isDragging, handleMouseDown } = useDraggable(initialRatio);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const loadData = type === 'busiest' ? fetchBusiestRanking : fetchRelaxedRanking;
+
+    loadData(3, controller.signal)
+      .then((data) => setEntries(data.rankings))
+      .catch((err) => {
+        if (err.name !== 'CanceledError') setError(true);
+      })
+      .finally(() => setLoading(false));
+
+    return () => controller.abort();
+  }, [type]);
+
+  const isBusiest = type === 'busiest';
+  const title = isBusiest ? 'Peak Congestion' : 'Quiet Getaways';
+  const Icon = isBusiest ? TrendingUp : TrendingDown;
+  const iconColor = isBusiest ? 'text-red-500' : 'text-green-500';
+
+  return (
+    <div
+      ref={ref}
+      onMouseDown={handleMouseDown}
+      className="fixed z-10 bg-white rounded-2xl shadow-2xl border border-gray-200 p-5 w-[16vw] min-w-56 max-w-80 select-none"
+      style={{
+        left: position.x,
+        top: position.y,
+        cursor: isDragging ? 'grabbing' : 'grab',
+        transform: `scale(${scale})`,
+        transformOrigin: 'top left',
+      }}
+    >
+      <div className="flex items-center gap-2 mb-4">
+        <Icon size={16} className={iconColor} />
+        <span className="text-base font-bold text-gray-900">{title}</span>
+      </div>
+
+      {loading ? (
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-6 bg-gray-100 rounded-lg animate-pulse" />
+          ))}
+        </div>
+      ) : error ? (
+        <p className="text-xs text-gray-400 text-center py-2">데이터를 불러올 수 없습니다</p>
+      ) : (
+        <div className="space-y-3">
+          {entries.map((entry, i) => {
+            const level = CONGESTION_LEVEL_MAP[entry.congestionLevel];
+            const color = level ? CONGESTION_COLORS[level] : '#9ca3af';
+            const label = level ? CONGESTION_LABELS[level] : entry.congestionLevel;
+            return (
+              <div key={entry.areaCode} className="flex items-center justify-between">
+                <div className="flex items-center gap-2.5 min-w-0">
+                  <span className="text-sm text-gray-400 shrink-0">
+                    {String(i + 1).padStart(2, '0')}
+                  </span>
+                  <span className="text-sm text-gray-800 font-medium truncate">
+                    {entry.areaName}
+                  </span>
+                </div>
+                <span
+                  className="text-xs font-semibold px-2.5 py-1 rounded-full text-white shrink-0 ml-2"
+                  style={{ backgroundColor: color }}
+                >
+                  {label}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      <button
+        onClick={() => navigate('/ranking')}
+        className="cursor-pointer flex items-center justify-center gap-1 w-full mt-4 text-sm text-blue-500 hover:text-blue-700 font-medium transition-colors"
+      >
+        자세히 보기
+        <ArrowRight size={14} />
+      </button>
+    </div>
+  );
+};
+
+export default CongestionRankCard;

--- a/src/components/congestion/CongestionRankCard.tsx
+++ b/src/components/congestion/CongestionRankCard.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { TrendingUp, TrendingDown, ArrowRight } from 'lucide-react';
+import axios from 'axios';
 import { fetchBusiestRanking, fetchRelaxedRanking } from '../../api/congestionApi';
 import { CONGESTION_LEVEL_MAP, CONGESTION_COLORS, CONGESTION_LABELS } from '../../types/congestion';
 import { useDraggable } from '../../hooks/useDraggable';
@@ -25,7 +26,7 @@ const CongestionRankCard = ({ type, initialRatio }: Props) => {
     loadData(3, controller.signal)
       .then((data) => setEntries(data.rankings))
       .catch((err) => {
-        if (err.name !== 'CanceledError') setError(true);
+        if (!axios.isCancel(err)) setError(true);
       })
       .finally(() => setLoading(false));
 
@@ -43,10 +44,10 @@ const CongestionRankCard = ({ type, initialRatio }: Props) => {
       onMouseDown={handleMouseDown}
       className="fixed z-10 bg-white rounded-2xl shadow-2xl border border-gray-200 p-5 w-[16vw] min-w-56 max-w-80 select-none"
       style={{
-        left: position.x,
-        top: position.y,
+        left: 0,
+        top: 0,
+        transform: `translate3d(${position.x}px, ${position.y}px, 0) scale(${scale})`,
         cursor: isDragging ? 'grabbing' : 'grab',
-        transform: `scale(${scale})`,
         transformOrigin: 'top left',
       }}
     >

--- a/src/components/congestion/CongestionRankCard.tsx
+++ b/src/components/congestion/CongestionRankCard.tsx
@@ -28,7 +28,9 @@ const CongestionRankCard = ({ type, initialRatio }: Props) => {
       .catch((err) => {
         if (!axios.isCancel(err)) setError(true);
       })
-      .finally(() => setLoading(false));
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
 
     return () => controller.abort();
   }, [type]);

--- a/src/hooks/useDraggable.ts
+++ b/src/hooks/useDraggable.ts
@@ -1,0 +1,100 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface Position {
+  x: number;
+  y: number;
+}
+
+const MARGIN = 20;
+const MARGIN_TOP = 72;
+const SCALE_MIN = 0.65;
+const SCALE_REF_HEIGHT = 820;
+
+function clamp(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(value, max));
+}
+
+export const useDraggable = (initialRatio: { x: number; y: number }) => {
+  const [ratio, setRatio] = useState(initialRatio);
+  const [cardSize, setCardSize] = useState({ width: 300, height: 200 });
+  const [isDragging, setIsDragging] = useState(false);
+  const [windowSize, setWindowSize] = useState({ w: window.innerWidth, h: window.innerHeight });
+  const ref = useRef<HTMLDivElement>(null);
+  const dragOrigin = useRef<{
+    mouseX: number;
+    mouseY: number;
+    cardX: number;
+    cardY: number;
+  } | null>(null);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const el = ref.current;
+    const update = () => {
+      if (el.offsetWidth > 0) setCardSize({ width: el.offsetWidth, height: el.offsetHeight });
+    };
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    const onResize = () => setWindowSize({ w: window.innerWidth, h: window.innerHeight });
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+
+  const scale = Math.min(1, Math.max(SCALE_MIN, windowSize.h / SCALE_REF_HEIGHT));
+
+  const position: Position = {
+    x: clamp(ratio.x * windowSize.w, MARGIN, windowSize.w - cardSize.width * scale - MARGIN),
+    y: clamp(ratio.y * windowSize.h, MARGIN_TOP, windowSize.h - cardSize.height * scale - MARGIN),
+  };
+
+  const handleMouseDown = (e: React.MouseEvent) => {
+    if ((e.target as HTMLElement).closest('button, a')) return;
+    e.preventDefault();
+    setIsDragging(true);
+    dragOrigin.current = {
+      mouseX: e.clientX,
+      mouseY: e.clientY,
+      cardX: position.x,
+      cardY: position.y,
+    };
+  };
+
+  useEffect(() => {
+    if (!isDragging) return;
+
+    const onMouseMove = (e: MouseEvent) => {
+      if (!dragOrigin.current || !ref.current) return;
+      const { width, height } = ref.current.getBoundingClientRect();
+      const newX = clamp(
+        dragOrigin.current.cardX + (e.clientX - dragOrigin.current.mouseX),
+        MARGIN,
+        window.innerWidth - width - MARGIN,
+      );
+      const newY = clamp(
+        dragOrigin.current.cardY + (e.clientY - dragOrigin.current.mouseY),
+        MARGIN_TOP,
+        window.innerHeight - height - MARGIN,
+      );
+      setRatio({ x: newX / window.innerWidth, y: newY / window.innerHeight });
+    };
+
+    const onMouseUp = () => {
+      setIsDragging(false);
+      dragOrigin.current = null;
+    };
+
+    window.addEventListener('mousemove', onMouseMove);
+    window.addEventListener('mouseup', onMouseUp);
+    return () => {
+      window.removeEventListener('mousemove', onMouseMove);
+      window.removeEventListener('mouseup', onMouseUp);
+    };
+  }, [isDragging]);
+
+  return { ref, position, scale, isDragging, handleMouseDown };
+};

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -4,6 +4,8 @@ import Header from '../components/layout/Header';
 import CategoryFilter from '../components/filter/CategoryFilter';
 import MapControls from '../components/map/MapControls';
 import CongestionLegend from '../components/congestion/CongestionLegend';
+import CongestionRankCard from '../components/congestion/CongestionRankCard';
+
 
 const HomePage = () => {
   const [selectedCategory, setSelectedCategory] = useState('all');
@@ -16,6 +18,8 @@ const HomePage = () => {
         <CategoryFilter selected={selectedCategory} onSelect={setSelectedCategory} />
         <MapControls onZoomIn={() => {}} onZoomOut={() => {}} onLocate={() => {}} />
         <CongestionLegend />
+        <CongestionRankCard type="busiest" initialRatio={{ x: 1, y: 0.13 }} />
+        <CongestionRankCard type="relaxed" initialRatio={{ x: 1, y: 0.40 }} />
       </div>
     </div>
   );

--- a/src/types/congestion.ts
+++ b/src/types/congestion.ts
@@ -40,6 +40,22 @@ export interface CongestionData {
   forecasts: ForecastItem[];
 }
 
+export interface RankingEntry {
+  rank: number;
+  areaCode: string;
+  areaName: string;
+  congestionLevel: string;
+  minPeopleCount: number;
+  maxPeopleCount: number;
+  populationTime: string;
+}
+
+export interface CongestionRankingResponse {
+  type: string;
+  totalCount: number;
+  rankings: RankingEntry[];
+}
+
 // 좌표 + 혼잡도가 합쳐진 마커 데이터
 export interface PlaceMarker {
   areaCode: string;


### PR DESCRIPTION
## 관련 이슈
Closes #24, #25

## 작업 내용

홈 화면 지도 위에 실시간 혼잡도 TOP3를 보여주는 드래그 가능한 오버레이 카드 2개를 구현했습니다.

**CongestionRankCard**
- Peak Congestion(가장 붐비는 곳 TOP3), Quiet Getaways(가장 여유로운 곳 TOP3) 카드 독립적으로 드래그 가능
- 자세히 보기 클릭 시 `/ranking`으로 이동
- API 실패 시 에러 메시지 표시, 언마운트 시 `AbortController`로 요청 취소

**useDraggable 커스텀 훅**
- `mousedown / mousemove / mouseup` 이벤트로 드래그 구현
- 위치를 절대 px 대신 뷰포트 비율(0~1)로 저장 -> 창 리사이즈 시 상대적 위치 유지
- `ResizeObserver`로 카드 크기 변화 감지 -> 경계 클램핑 정확도 유지
- 창이 작아질 때 `transform: scale()`로 카드 자동 축소

## 참고
- 모바일 터치 드래그는 별도 이슈에서 대응 예정
