### PR TITLE
feat: 랭킹 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { Routes, Route } from 'react-router-dom';
 import HomePage from './pages/HomePage';
 import DetailPage from './pages/DetailPage';
 import RankingPage from './pages/RankingPage';
+import HotspotsPage from './pages/HotspotsPage';
 
 function App() {
   return (
@@ -9,6 +10,7 @@ function App() {
       <Route path="/" element={<HomePage />} />
       <Route path="/place/:placeId" element={<DetailPage />} />
       <Route path="/ranking" element={<RankingPage />} />
+      <Route path="/hotspots" element={<HotspotsPage />} />
     </Routes>
   );
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -4,7 +4,7 @@ import { MapPin, Search, Bell, Menu, X } from 'lucide-react';
 
 const NAV_LINKS = [
   { label: 'Live Map', path: '/' },
-  { label: 'Hotspots', path: '/ranking' },
+  { label: 'Hotspots', path: '/hotspots' },
   { label: 'Route Planner', path: '/route' },
 ];
 

--- a/src/hooks/useRanking.ts
+++ b/src/hooks/useRanking.ts
@@ -1,0 +1,44 @@
+import { useEffect, useReducer } from 'react';
+import axios from 'axios';
+import { fetchBusiestRanking, fetchRelaxedRanking } from '../api/congestionApi';
+import type { RankingEntry } from '../types/congestion';
+
+type State = { entries: RankingEntry[]; loading: boolean; error: boolean };
+type Action =
+  | { type: 'reset' }
+  | { type: 'success'; entries: RankingEntry[] }
+  | { type: 'error' };
+
+function rankingReducer(_: State, action: Action): State {
+  switch (action.type) {
+    case 'reset': return { entries: [], loading: true, error: false };
+    case 'success': return { entries: action.entries, loading: false, error: false };
+    case 'error': return { entries: [], loading: false, error: true };
+  }
+}
+
+export const useRanking = (tab: 'busiest' | 'relaxed') => {
+  const [state, dispatch] = useReducer(rankingReducer, { entries: [], loading: true, error: false });
+
+  useEffect(() => {
+    const controller = new AbortController();
+    dispatch({ type: 'reset' });
+    const loadData = tab === 'busiest' ? fetchBusiestRanking : fetchRelaxedRanking;
+
+    loadData(122, controller.signal)
+      .then((data) => {
+        if (!controller.signal.aborted) {
+          dispatch({ type: 'success', entries: data.rankings });
+        }
+      })
+      .catch((err) => {
+        if (!axios.isCancel(err)) {
+          dispatch({ type: 'error' });
+        }
+      });
+
+    return () => controller.abort();
+  }, [tab]);
+
+  return state;
+};

--- a/src/hooks/useRanking.ts
+++ b/src/hooks/useRanking.ts
@@ -1,4 +1,6 @@
 import { useEffect, useReducer } from 'react';
+
+const RANKING_LIMIT = 122;
 import axios from 'axios';
 import { fetchBusiestRanking, fetchRelaxedRanking } from '../api/congestionApi';
 import type { RankingEntry } from '../types/congestion';
@@ -25,7 +27,7 @@ export const useRanking = (tab: 'busiest' | 'relaxed') => {
     dispatch({ type: 'reset' });
     const loadData = tab === 'busiest' ? fetchBusiestRanking : fetchRelaxedRanking;
 
-    loadData(122, controller.signal)
+    loadData(RANKING_LIMIT, controller.signal)
       .then((data) => {
         if (!controller.signal.aborted) {
           dispatch({ type: 'success', entries: data.rankings });

--- a/src/pages/HotspotsPage.tsx
+++ b/src/pages/HotspotsPage.tsx
@@ -1,0 +1,14 @@
+import Header from '../components/layout/Header';
+
+const HotspotsPage = () => {
+  return (
+    <div className="flex flex-col w-full min-h-dvh bg-gray-50">
+      <Header />
+      <div className="flex flex-1 items-center justify-center">
+        <h1 className="text-2xl font-bold text-gray-900">Hotspots</h1>
+      </div>
+    </div>
+  );
+};
+
+export default HotspotsPage;

--- a/src/pages/RankingPage.tsx
+++ b/src/pages/RankingPage.tsx
@@ -1,5 +1,143 @@
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { TrendingUp, TrendingDown, ArrowLeft, Users } from 'lucide-react';
+import Header from '../components/layout/Header';
+import { useRanking } from '../hooks/useRanking';
+import { LOCATION_MAP } from '../data/locations';
+import { CATEGORY_LABELS } from '../data/categories';
+import { CONGESTION_LEVEL_MAP, CONGESTION_COLORS, CONGESTION_LABELS } from '../types/congestion';
+import type { RankingEntry } from '../types/congestion';
+
+const RANK_BADGE: Record<number, string> = {
+  1: 'bg-yellow-400 text-white',
+  2: 'bg-gray-400 text-white',
+  3: 'bg-amber-600 text-white',
+};
+
+interface RankingItemProps {
+  entry: RankingEntry;
+  onClick: () => void;
+}
+
+const RankingItem = ({ entry, onClick }: RankingItemProps) => {
+  const level = CONGESTION_LEVEL_MAP[entry.congestionLevel];
+  const color = level ? CONGESTION_COLORS[level] : '#9ca3af';
+  const label = level ? CONGESTION_LABELS[level] : entry.congestionLevel;
+  const location = LOCATION_MAP.get(entry.areaCode);
+  const category = location ? (CATEGORY_LABELS[location.category] ?? location.category) : null;
+  const avgPeople = Math.round((entry.minPeopleCount + entry.maxPeopleCount) / 2);
+
+  return (
+    <div
+      onClick={onClick}
+      className="cursor-pointer bg-white rounded-2xl px-8 py-5 flex items-center gap-6 hover:shadow-md transition-shadow"
+    >
+      <div
+        className={`w-14 h-14 rounded-full flex items-center justify-center text-lg font-bold shrink-0 ${
+          RANK_BADGE[entry.rank] ?? 'bg-gray-100 text-gray-500'
+        }`}
+      >
+        {entry.rank}
+      </div>
+
+      <div className="flex-1 min-w-0">
+        <p className="text-lg font-semibold text-gray-900 truncate">{entry.areaName}</p>
+        <div className="flex items-center gap-3 mt-1.5">
+          {category && <span className="text-base text-gray-400">{category}</span>}
+          <span className="flex items-center gap-1 text-base text-gray-400">
+            <Users size={15} />
+            {avgPeople.toLocaleString()}명
+          </span>
+        </div>
+      </div>
+
+      <span
+        className="text-base font-semibold px-5 py-2 rounded-full text-white shrink-0"
+        style={{ backgroundColor: color }}
+      >
+        {label}
+      </span>
+    </div>
+  );
+};
+
 const RankingPage = () => {
-  return <div>RankingPage</div>;
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const tab = (searchParams.get('tab') ?? 'busiest') as 'busiest' | 'relaxed';
+
+  const { entries, loading, error } = useRanking(tab);
+  const isBusiest = tab === 'busiest';
+
+  return (
+    <div className="flex flex-col w-full min-h-dvh bg-gray-50">
+      <Header />
+      <div className="max-w-7xl mx-auto w-full px-6 py-8">
+        <button
+          onClick={() => navigate('/')}
+          className="cursor-pointer flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-800 mb-8 transition-colors"
+        >
+          <ArrowLeft size={16} />
+          메인으로 돌아가기
+        </button>
+
+        <h1 className="text-3xl font-bold text-gray-900">실시간 랭킹</h1>
+        <p className="text-base text-gray-400 mt-1.5">
+          서울 핫플레이스의 실시간 혼잡도를 확인하세요
+        </p>
+
+        <div className="flex gap-8 mt-8 border-b border-gray-200">
+          <button
+            onClick={() => setSearchParams({ tab: 'busiest' })}
+            className={`cursor-pointer flex items-center gap-2 pb-3 text-base font-medium border-b-2 transition-colors ${
+              isBusiest
+                ? 'border-red-500 text-red-500'
+                : 'border-transparent text-gray-400 hover:text-gray-600'
+            }`}
+          >
+            <TrendingUp size={17} />
+            혼잡도 높은 순
+          </button>
+          <button
+            onClick={() => setSearchParams({ tab: 'relaxed' })}
+            className={`cursor-pointer flex items-center gap-2 pb-3 text-base font-medium border-b-2 transition-colors ${
+              !isBusiest
+                ? 'border-green-500 text-green-500'
+                : 'border-transparent text-gray-400 hover:text-gray-600'
+            }`}
+          >
+            <TrendingDown size={17} />
+            혼잡도 낮은 순
+          </button>
+        </div>
+
+        <div className="mt-5 space-y-3">
+          {loading && (
+            <>
+              {Array.from({ length: 5 }).map((_, i) => (
+                <div key={i} className="h-24 bg-white rounded-2xl animate-pulse" />
+              ))}
+            </>
+          )}
+
+          {!loading && error && (
+            <div className="bg-white rounded-2xl p-8 text-center text-gray-400">
+              데이터를 불러올 수 없습니다
+            </div>
+          )}
+
+          {!loading &&
+            !error &&
+            entries.map((entry) => (
+              <RankingItem
+                key={entry.areaCode}
+                entry={entry}
+                onClick={() => navigate(`/place/${entry.areaCode}`)}
+              />
+            ))}
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export default RankingPage;

--- a/src/pages/RankingPage.tsx
+++ b/src/pages/RankingPage.tsx
@@ -63,7 +63,8 @@ const RankingItem = ({ entry, onClick }: RankingItemProps) => {
 const RankingPage = () => {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
-  const tab = (searchParams.get('tab') ?? 'busiest') as 'busiest' | 'relaxed';
+  const tabParam = searchParams.get('tab');
+  const tab: 'busiest' | 'relaxed' = tabParam === 'relaxed' ? 'relaxed' : 'busiest';
 
   const { entries, loading, error } = useRanking(tab);
   const isBusiest = tab === 'busiest';


### PR DESCRIPTION
## 관련 이슈
Closes #26

## 작업 내용

**RankingPage**
- 혼잡도 높은 순 / 낮은 순 탭 전환
- URL 쿼리 파라미터(`?tab=busiest`)로 탭 상태 관리 -> 새로고침/뒤로가기 유지
- 카드 클릭 시 장소 상세 페이지(`/place/:areaCode`)로 이동
- 로딩 스켈레톤, 에러 메시지, 데이터 세 가지 상태 처리

**useRanking 커스텀 훅**
- 탭 전환 시 AbortController로 이전 요청 취소
- useReducer로 상태 관리 (reset -> success/error)

**기타**
- HotspotsPage 추가 및 헤더 Hotspots 링크를 `/hotspots`로 변경
