### PR TITLE
feat: HotspotsPage 구현

### DIFF
--- a/src/components/map/CongestionMarker.tsx
+++ b/src/components/map/CongestionMarker.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { CustomOverlayMap } from 'react-kakao-maps-sdk';
 import { MapPin, X } from 'lucide-react';
 import { CONGESTION_COLORS, CONGESTION_LABELS } from '../../types/congestion';
-import { CATEGORY_LABELS } from '../../data/categories';
+import { CATEGORY_NAMES } from '../../data/categories';
 import type { PlaceMarker } from '../../types/congestion';
 
 interface CongestionMarkerProps {
@@ -71,7 +71,7 @@ const CongestionMarker = ({ marker, level }: CongestionMarkerProps) => {
 
               <div className="flex gap-1 mb-2">
                 <span className="text-xs text-gray-500 bg-gray-100 rounded-full px-2 py-0.5">
-                  {CATEGORY_LABELS[marker.category] ?? marker.category}
+                  {`#${CATEGORY_NAMES[marker.category as keyof typeof CATEGORY_NAMES] ?? marker.category}`}
                 </span>
               </div>
 

--- a/src/data/categories.ts
+++ b/src/data/categories.ts
@@ -1,6 +1,8 @@
-export const CATEGORY_LABELS: Record<string, string> = {
-  cafe: '#카페',
-  shopping: '#쇼핑',
-  park: '#공원',
-  culture: '#문화',
+import type { LocationCategory } from './locations';
+
+export const CATEGORY_NAMES: Record<LocationCategory, string> = {
+  cafe: '카페',
+  shopping: '쇼핑',
+  park: '공원',
+  culture: '문화',
 };

--- a/src/data/locations.ts
+++ b/src/data/locations.ts
@@ -11,6 +11,9 @@ export interface Location {
   category: LocationCategory;
 }
 
+export const getLocationImageUrl = (name: string): string =>
+  `https://data.seoul.go.kr/SeoulRtd/images/hotspot/${encodeURIComponent(name)}.jpg`;
+
 export const LOCATIONS: Location[] = [
   {
     areaCode: 'POI001',

--- a/src/hooks/useHotspotsFilter.ts
+++ b/src/hooks/useHotspotsFilter.ts
@@ -1,0 +1,88 @@
+import { useSearchParams } from 'react-router-dom';
+import { LOCATIONS } from '../data/locations';
+import type { LocationCategory } from '../data/locations';
+
+export type FilterCategory = LocationCategory | 'all';
+
+const PAGE_SIZE = 12;
+
+function getPageNumbers(current: number, total: number): (number | null)[] {
+  if (total <= 7) return Array.from({ length: total }, (_, i) => i + 1);
+
+  const shown = new Set(
+    [1, total, current, current - 1, current + 1].filter((p) => p >= 1 && p <= total),
+  );
+  const sorted = [...shown].sort((a, b) => a - b);
+
+  const result: (number | null)[] = [];
+  for (let i = 0; i < sorted.length; i++) {
+    if (i > 0 && sorted[i] - sorted[i - 1] > 1) result.push(null);
+    result.push(sorted[i]);
+  }
+  return result;
+}
+
+export function useHotspotsFilter(searchValue: string) {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const categoryParam = searchParams.get('category') ?? 'all';
+  const activeCategory: FilterCategory = ['cafe', 'shopping', 'park', 'culture'].includes(
+    categoryParam,
+  )
+    ? (categoryParam as LocationCategory)
+    : 'all';
+  const pageParam = parseInt(searchParams.get('page') ?? '1', 10);
+
+  const filtered = LOCATIONS.filter((loc) => {
+    const matchesQuery = loc.name.includes(searchValue);
+    const matchesCategory = activeCategory === 'all' || loc.category === activeCategory;
+    return matchesQuery && matchesCategory;
+  });
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const currentPage =
+    Number.isNaN(pageParam) || pageParam < 1 ? 1 : Math.min(pageParam, totalPages);
+  const paged = filtered.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE);
+
+  const buildParams = (overrides: Record<string, string>) => {
+    const params: Record<string, string> = {};
+    if (searchValue) params.q = searchValue;
+    if (activeCategory !== 'all') params.category = activeCategory;
+    if (currentPage !== 1) params.page = String(currentPage);
+    return { ...params, ...overrides };
+  };
+
+  const commitSearch = (value: string) => {
+    const params: Record<string, string> = {};
+    if (value) params.q = value;
+    if (activeCategory !== 'all') params.category = activeCategory;
+    setSearchParams(params);
+  };
+
+  const handleCategory = (value: FilterCategory) => {
+    const params = buildParams({});
+    delete params.page;
+    if (value === 'all') delete params.category;
+    else params.category = value;
+    setSearchParams(params);
+  };
+
+  const handlePage = (page: number) => {
+    const params = buildParams({ page: String(page) });
+    if (page === 1) delete params.page;
+    setSearchParams(params);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  return {
+    activeCategory,
+    currentPage,
+    totalPages,
+    filteredCount: filtered.length,
+    paged,
+    pageNumbers: getPageNumbers(currentPage, totalPages),
+    commitSearch,
+    handleCategory,
+    handlePage,
+  };
+}

--- a/src/hooks/useHotspotsFilter.ts
+++ b/src/hooks/useHotspotsFilter.ts
@@ -34,7 +34,7 @@ export function useHotspotsFilter(searchValue: string) {
   const pageParam = parseInt(searchParams.get('page') ?? '1', 10);
 
   const filtered = LOCATIONS.filter((loc) => {
-    const matchesQuery = loc.name.includes(searchValue);
+    const matchesQuery = loc.name.toLowerCase().includes(searchValue.toLowerCase());
     const matchesCategory = activeCategory === 'all' || loc.category === activeCategory;
     return matchesQuery && matchesCategory;
   });
@@ -56,7 +56,7 @@ export function useHotspotsFilter(searchValue: string) {
     const params: Record<string, string> = {};
     if (value) params.q = value;
     if (activeCategory !== 'all') params.category = activeCategory;
-    setSearchParams(params);
+    setSearchParams(params, { replace: true });
   };
 
   const handleCategory = (value: FilterCategory) => {

--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -3,8 +3,8 @@ import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { ArrowLeft, Users, Clock } from 'lucide-react';
 import Header from '../components/layout/Header';
 import { fetchCongestionByAreaCode } from '../api/congestionApi';
-import { LOCATION_MAP } from '../data/locations';
-import { CATEGORY_LABELS } from '../data/categories';
+import { LOCATION_MAP, getLocationImageUrl } from '../data/locations';
+import { CATEGORY_NAMES } from '../data/categories';
 import { CONGESTION_COLORS, CONGESTION_LABELS, CONGESTION_LEVEL_MAP } from '../types/congestion';
 import type { CongestionData, PlaceMarker } from '../types/congestion';
 
@@ -63,45 +63,57 @@ const DetailPage = () => {
         )}
 
         {!loading && (marker || data) && placeInfo && congestionLevel && (
-          <div className="bg-white rounded-2xl p-6 shadow-sm">
-            <div className="flex items-start justify-between">
-              <div>
-                <h1 className="text-2xl font-bold text-gray-900">{placeInfo.name}</h1>
-                <div className="flex gap-1.5 mt-2">
-                  <span className="text-xs text-gray-500 bg-gray-100 rounded-full px-2.5 py-1">
-                    {CATEGORY_LABELS[placeInfo.category] ?? placeInfo.category}
-                  </span>
-                </div>
-              </div>
-              <span
-                className="text-sm font-bold px-3 py-1.5 rounded-full text-white mt-1 shrink-0"
-                style={{ backgroundColor: color }}
-              >
-                {CONGESTION_LABELS[congestionLevel]}
-              </span>
+          <div className="bg-white rounded-2xl overflow-hidden shadow-sm">
+            <div className="relative bg-gray-100">
+              <img
+                src={getLocationImageUrl(placeInfo.name)}
+                alt={placeInfo.name}
+                className="w-full h-56 object-cover"
+                onError={(e) => {
+                  e.currentTarget.style.visibility = 'hidden';
+                }}
+              />
             </div>
-
-            {congestionMessage && (
-              <p className="mt-4 text-sm text-gray-600 leading-relaxed">{congestionMessage}</p>
-            )}
-
-            <div className="flex gap-8 mt-6">
-              <div className="flex items-center gap-3">
-                <div className="w-10 h-10 bg-blue-50 rounded-xl flex items-center justify-center">
-                  <Users size={18} className="text-blue-500" />
-                </div>
+            <div className="p-6">
+              <div className="flex items-start justify-between">
                 <div>
-                  <p className="text-xs text-gray-400">Current Visitors</p>
-                  <p className="text-xl font-bold text-gray-900">{avgPeople.toLocaleString()}</p>
+                  <h1 className="text-2xl font-bold text-gray-900">{placeInfo.name}</h1>
+                  <div className="flex gap-1.5 mt-2">
+                    <span className="text-xs text-gray-500 bg-gray-100 rounded-full px-2.5 py-1">
+                      {`#${CATEGORY_NAMES[placeInfo.category]}`}
+                    </span>
+                  </div>
                 </div>
+                <span
+                  className="text-sm font-bold px-3 py-1.5 rounded-full text-white mt-1 shrink-0"
+                  style={{ backgroundColor: color }}
+                >
+                  {CONGESTION_LABELS[congestionLevel]}
+                </span>
               </div>
-              <div className="flex items-center gap-3">
-                <div className="w-10 h-10 bg-purple-50 rounded-xl flex items-center justify-center">
-                  <Clock size={18} className="text-purple-500" />
+
+              {congestionMessage && (
+                <p className="mt-4 text-sm text-gray-600 leading-relaxed">{congestionMessage}</p>
+              )}
+
+              <div className="flex gap-8 mt-6">
+                <div className="flex items-center gap-3">
+                  <div className="w-10 h-10 bg-blue-50 rounded-xl flex items-center justify-center">
+                    <Users size={18} className="text-blue-500" />
+                  </div>
+                  <div>
+                    <p className="text-xs text-gray-400">Current Visitors</p>
+                    <p className="text-xl font-bold text-gray-900">{avgPeople.toLocaleString()}</p>
+                  </div>
                 </div>
-                <div>
-                  <p className="text-xs text-gray-400">Updated</p>
-                  <p className="text-sm font-medium text-gray-900">{populationTime}</p>
+                <div className="flex items-center gap-3">
+                  <div className="w-10 h-10 bg-purple-50 rounded-xl flex items-center justify-center">
+                    <Clock size={18} className="text-purple-500" />
+                  </div>
+                  <div>
+                    <p className="text-xs text-gray-400">Updated</p>
+                    <p className="text-sm font-medium text-gray-900">{populationTime}</p>
+                  </div>
                 </div>
               </div>
             </div>

--- a/src/pages/HotspotsPage.tsx
+++ b/src/pages/HotspotsPage.tsx
@@ -1,11 +1,201 @@
+import { useRef, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import {
+  TrendingUp,
+  Search,
+  Sparkles,
+  Coffee,
+  ShoppingBag,
+  Trees,
+  Landmark,
+  ChevronLeft,
+  ChevronRight,
+} from 'lucide-react';
 import Header from '../components/layout/Header';
+import { getLocationImageUrl } from '../data/locations';
+import { CATEGORY_NAMES } from '../data/categories';
+import { useHotspotsFilter } from '../hooks/useHotspotsFilter';
+import type { FilterCategory } from '../hooks/useHotspotsFilter';
+
+const CATEGORY_FILTERS: { value: FilterCategory; label: string; icon: React.ElementType }[] = [
+  { value: 'all', label: 'All', icon: Sparkles },
+  { value: 'cafe', label: 'Cafe', icon: Coffee },
+  { value: 'shopping', label: 'Shopping', icon: ShoppingBag },
+  { value: 'park', label: 'Park', icon: Trees },
+  { value: 'culture', label: 'Culture', icon: Landmark },
+];
 
 const HotspotsPage = () => {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const [inputValue, setInputValue] = useState(searchParams.get('q') ?? '');
+  const isComposing = useRef(false);
+
+  const {
+    activeCategory,
+    currentPage,
+    totalPages,
+    filteredCount,
+    paged,
+    pageNumbers,
+    commitSearch,
+    handleCategory,
+    handlePage,
+  } = useHotspotsFilter(inputValue);
+
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputValue(e.target.value);
+    if (!isComposing.current) commitSearch(e.target.value);
+  };
+
+  const handleCompositionStart = () => {
+    isComposing.current = true;
+  };
+
+  const handleCompositionEnd = (e: React.CompositionEvent<HTMLInputElement>) => {
+    isComposing.current = false;
+    commitSearch(e.currentTarget.value);
+  };
+
   return (
     <div className="flex flex-col w-full min-h-dvh bg-gray-50">
       <Header />
-      <div className="flex flex-1 items-center justify-center">
-        <h1 className="text-2xl font-bold text-gray-900">Hotspots</h1>
+      <div className="max-w-7xl mx-auto w-full px-6 py-8">
+        <div className="flex items-start justify-between mb-6">
+          <div>
+            <div className="flex items-center gap-2 mb-1">
+              <TrendingUp size={22} className="text-blue-600" />
+              <h1 className="text-3xl font-bold text-gray-900">서울 핫플레이스</h1>
+            </div>
+            <p className="text-base text-gray-500">
+              서울 주요 핫플레이스{' '}
+              <span className="text-blue-600 font-medium">{filteredCount}곳</span>의 정보를
+              제공합니다
+            </p>
+          </div>
+          <div className="flex items-center gap-1.5 text-sm text-green-500 font-medium mt-1">
+            <span className="w-2 h-2 rounded-full bg-green-500 animate-pulse" />
+            실시간
+          </div>
+        </div>
+
+        <div className="relative mb-4">
+          <Search size={16} className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400" />
+          <input
+            type="text"
+            value={inputValue}
+            onChange={handleSearchChange}
+            onCompositionStart={handleCompositionStart}
+            onCompositionEnd={handleCompositionEnd}
+            placeholder="핫플레이스 검색..."
+            className="w-full pl-10 pr-4 py-3 bg-white border border-gray-200 rounded-xl text-sm outline-none focus:border-blue-400 transition-colors"
+          />
+        </div>
+
+        <div className="flex gap-2 mb-8 flex-wrap">
+          {CATEGORY_FILTERS.map(({ value, label, icon: Icon }) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => handleCategory(value)}
+              className={`cursor-pointer flex items-center gap-1.5 px-4 py-2 rounded-full text-sm font-medium transition-colors ${
+                activeCategory === value
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-white text-gray-600 hover:bg-gray-100 border border-gray-200'
+              }`}
+            >
+              <Icon size={14} />
+              {label}
+            </button>
+          ))}
+        </div>
+
+        {filteredCount === 0 ? (
+          <div className="text-center py-20 text-gray-400">검색 결과가 없습니다</div>
+        ) : (
+          <>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+              {paged.map((loc) => (
+                <button
+                  key={loc.areaCode}
+                  type="button"
+                  onClick={() => navigate(`/place/${loc.areaCode}`)}
+                  className="text-left cursor-pointer bg-white rounded-2xl overflow-hidden shadow-sm hover:shadow-md transition-shadow"
+                >
+                  <div className="relative bg-gray-100">
+                    <img
+                      src={getLocationImageUrl(loc.name)}
+                      alt={loc.name}
+                      className="w-full h-52 object-cover"
+                      onError={(e) => {
+                        e.currentTarget.style.visibility = 'hidden';
+                      }}
+                    />
+                    <span className="absolute top-3 left-3 bg-white/90 text-gray-700 text-xs font-medium px-2.5 py-1 rounded-full">
+                      {CATEGORY_NAMES[loc.category]}
+                    </span>
+                  </div>
+                  <div className="p-5">
+                    <h2 className="text-lg font-bold text-gray-900 mb-2">{loc.name}</h2>
+                    <span className="text-sm text-blue-500 font-medium">
+                      #{CATEGORY_NAMES[loc.category]}
+                    </span>
+                  </div>
+                </button>
+              ))}
+            </div>
+
+            {totalPages > 1 && (
+              <div className="flex items-center justify-center gap-1 mt-10">
+                <button
+                  type="button"
+                  onClick={() => handlePage(currentPage - 1)}
+                  disabled={currentPage === 1}
+                  className="cursor-pointer p-2 rounded-lg text-gray-400 hover:bg-gray-100 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                >
+                  <ChevronLeft size={18} />
+                </button>
+
+                {pageNumbers.map((page, i) =>
+                  page === null ? (
+                    <span
+                      key={`ellipsis-${i}`}
+                      className="w-9 h-9 inline-flex items-center justify-center text-gray-400"
+                    >
+                      ...
+                    </span>
+                  ) : (
+                    <button
+                      key={page}
+                      type="button"
+                      onClick={() => handlePage(page)}
+                      className={`cursor-pointer w-9 h-9 rounded-lg text-sm font-medium transition-colors ${
+                        page === currentPage
+                          ? 'bg-blue-600 text-white'
+                          : 'text-gray-600 hover:bg-gray-100'
+                      }`}
+                    >
+                      {page}
+                    </button>
+                  ),
+                )}
+
+                <button
+                  type="button"
+                  onClick={() => handlePage(currentPage + 1)}
+                  disabled={currentPage === totalPages}
+                  className="cursor-pointer p-2 rounded-lg text-gray-400 hover:bg-gray-100 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                >
+                  <ChevronRight size={18} />
+                </button>
+              </div>
+            )}
+          </>
+        )}
+
+        <p className="text-xs text-gray-400 text-center mt-12">
+          이미지 출처: 서울 실시간 도시데이터 (공공누리 제1유형)
+        </p>
       </div>
     </div>
   );

--- a/src/pages/RankingPage.tsx
+++ b/src/pages/RankingPage.tsx
@@ -3,7 +3,7 @@ import { TrendingUp, TrendingDown, ArrowLeft, Users } from 'lucide-react';
 import Header from '../components/layout/Header';
 import { useRanking } from '../hooks/useRanking';
 import { LOCATION_MAP } from '../data/locations';
-import { CATEGORY_LABELS } from '../data/categories';
+import { CATEGORY_NAMES } from '../data/categories';
 import { CONGESTION_LEVEL_MAP, CONGESTION_COLORS, CONGESTION_LABELS } from '../types/congestion';
 import type { RankingEntry } from '../types/congestion';
 
@@ -23,7 +23,7 @@ const RankingItem = ({ entry, onClick }: RankingItemProps) => {
   const color = level ? CONGESTION_COLORS[level] : '#9ca3af';
   const label = level ? CONGESTION_LABELS[level] : entry.congestionLevel;
   const location = LOCATION_MAP.get(entry.areaCode);
-  const category = location ? (CATEGORY_LABELS[location.category] ?? location.category) : null;
+  const category = location ? `#${CATEGORY_NAMES[location.category]}` : null;
   const avgPeople = Math.round((entry.minPeopleCount + entry.maxPeopleCount) / 2);
 
   return (


### PR DESCRIPTION
## 관련 이슈
Closes #31, #32

## 작업 내용

**HotspotsPage**
- 장소 카드 이미지 표시, 로드 실패 시 회색 배경 fallback 처리
- 실시간 검색 필터링 및 한글 IME 깨짐 수정
- 카테고리 필터 (전체, 카페, 쇼핑, 공원, 문화)
- 페이지당 12개 페이지네이션, URL 기반 상태 관리 (`?q=&category=&page=`)
- 검색, 카테고리 변경 시 1페이지 자동 리셋

**useHotspotsFilter 커스텀 훅**
- URL 파라미터 파싱, 필터링, 페이지네이션 계산 분리

**기타**
- `locations.ts`에 `getLocationImageUrl` 함수 추가
- DetailPage 상단 장소 이미지 추가
- `CATEGORY_LABELS` 제거, `CATEGORY_NAMES`로 통일
