### PR TITLE
feat: 행사/문화 정보 뷰 구현

### DIFF
--- a/src/api/mapApi.ts
+++ b/src/api/mapApi.ts
@@ -1,0 +1,15 @@
+import instance from './instance';
+import type { ApiResponse } from '../types/api';
+import type { CultureEvent } from '../types/map';
+
+export const fetchCultureEvents = async (
+  latitude: number,
+  longitude: number,
+  signal?: AbortSignal,
+): Promise<CultureEvent[]> => {
+  const res = await instance.get<ApiResponse<CultureEvent[]>>('/api/map/culture-events', {
+    params: { latitude, longitude },
+    signal,
+  });
+  return res.data.data;
+};

--- a/src/components/culture/CultureEventCard.tsx
+++ b/src/components/culture/CultureEventCard.tsx
@@ -1,0 +1,52 @@
+import { ExternalLink } from 'lucide-react';
+import type { CultureEvent } from '../../types/map';
+
+interface Props {
+  event: CultureEvent;
+}
+
+const formatDate = (dateStr: string) => {
+  const d = new Date(dateStr);
+  return `${d.getFullYear()}.${String(d.getMonth() + 1).padStart(2, '0')}.${String(d.getDate()).padStart(2, '0')}`;
+};
+
+const CultureEventCard = ({ event }: Props) => {
+  return (
+    <div className="bg-white rounded-2xl overflow-hidden shadow-sm flex flex-col">
+      <div className="h-36 bg-gray-100 overflow-hidden shrink-0">
+        <img
+          src={event.mainImg}
+          alt={event.title}
+          className="w-full h-full object-cover"
+          onError={(e) => {
+            e.currentTarget.style.visibility = 'hidden';
+          }}
+        />
+      </div>
+      <div className="p-4 flex flex-col gap-2 flex-1">
+        <span className="text-xs text-blue-500 bg-blue-50 rounded-full px-2.5 py-0.5 w-fit">
+          {event.codename}
+        </span>
+        <p className="text-sm font-semibold text-gray-900 line-clamp-2 leading-snug">
+          {event.title}
+        </p>
+        <p className="text-xs text-gray-400">{event.place}</p>
+        <p className="text-xs text-gray-500">
+          {formatDate(event.startDate)} ~ {formatDate(event.endDate)}
+        </p>
+        {event.useFee && <p className="text-xs text-gray-500">요금: {event.useFee}</p>}
+        <a
+          href={event.orgLink}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-auto pt-2 flex items-center gap-1 text-xs text-blue-500 hover:text-blue-700 transition-colors w-fit"
+        >
+          자세히 보기
+          <ExternalLink size={11} />
+        </a>
+      </div>
+    </div>
+  );
+};
+
+export default CultureEventCard;

--- a/src/hooks/useCultureEvents.ts
+++ b/src/hooks/useCultureEvents.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import { fetchCultureEvents } from '../api/mapApi';
+import type { CultureEvent } from '../types/map';
+
+type State =
+  | { status: 'loading' }
+  | { status: 'success'; data: CultureEvent[] }
+  | { status: 'error' };
+
+export const useCultureEvents = (latitude: number | null, longitude: number | null) => {
+  const [state, setState] = useState<State>({ status: 'loading' });
+
+  useEffect(() => {
+    if (latitude == null || longitude == null) return;
+
+    const controller = new AbortController();
+
+    fetchCultureEvents(latitude, longitude, controller.signal)
+      .then((data) => {
+        if (!controller.signal.aborted) setState({ status: 'success', data });
+      })
+      .catch((err) => {
+        if (!axios.isCancel(err)) setState({ status: 'error' });
+      });
+
+    return () => controller.abort();
+  }, [latitude, longitude]);
+
+  return state;
+};

--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -2,7 +2,9 @@ import { useEffect, useState } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { ArrowLeft, Users, Clock } from 'lucide-react';
 import Header from '../components/layout/Header';
+import CultureEventCard from '../components/culture/CultureEventCard';
 import { fetchCongestionByAreaCode } from '../api/congestionApi';
+import { useCultureEvents } from '../hooks/useCultureEvents';
 import { LOCATION_MAP, getLocationImageUrl } from '../data/locations';
 import { CATEGORY_NAMES } from '../data/categories';
 import { CONGESTION_COLORS, CONGESTION_LABELS, CONGESTION_LEVEL_MAP } from '../types/congestion';
@@ -18,6 +20,8 @@ const DetailPage = () => {
 
   const placeInfo = placeId ? LOCATION_MAP.get(placeId) : null;
   const hasMarkerState = !!locationState?.marker;
+
+  const eventsState = useCultureEvents(placeInfo?.latitude ?? null, placeInfo?.longitude ?? null);
 
   useEffect(() => {
     if (!placeId || hasMarkerState) return;
@@ -117,6 +121,35 @@ const DetailPage = () => {
                 </div>
               </div>
             </div>
+          </div>
+        )}
+        {placeInfo && (
+          <div className="mt-6">
+            <h2 className="text-base font-bold text-gray-800 mb-3">주변 행사/문화 정보</h2>
+            {eventsState.status === 'loading' && (
+              <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <div key={i} className="bg-white rounded-2xl shadow-sm animate-pulse h-56" />
+                ))}
+              </div>
+            )}
+            {eventsState.status === 'error' && (
+              <div className="bg-white rounded-2xl p-6 shadow-sm text-center text-gray-400 text-sm">
+                행사 정보를 불러올 수 없어요.
+              </div>
+            )}
+            {eventsState.status === 'success' && eventsState.data.length === 0 && (
+              <div className="bg-white rounded-2xl p-6 shadow-sm text-center text-gray-400 text-sm">
+                주변 행사/문화 정보가 없어요.
+              </div>
+            )}
+            {eventsState.status === 'success' && eventsState.data.length > 0 && (
+              <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+                {eventsState.data.map((event) => (
+                  <CultureEventCard key={event.orgLink} event={event} />
+                ))}
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -1,0 +1,12 @@
+export interface CultureEvent {
+  title: string;
+  place: string;
+  codename: string;
+  startDate: string;
+  endDate: string;
+  useFee: string | null;
+  orgLink: string;
+  mainImg: string;
+  latitude: number;
+  longitude: number;
+}


### PR DESCRIPTION
## 관련 이슈
Closes #35 

## 작업 내용

**DetailPage -  주변 행사/문화 섹션 추가**
- 장소 좌표 기준 1km 이내 문화/행사 이벤트 카드 목록 표시
- 로딩 스켈레톤, 이벤트 없을 때 빈 상태 메시지, 에러 메시지 처리

**CultureEventCard**
- 이미지, 카테고리 태그, 제목, 장소명, 기간 표시
- `useFee` null일 때 요금 항목 미표시
- `orgLink` 새 탭으로 열기