### PR TITLE
feat: 대체지역 추천 뷰 구현

### DIFF
--- a/src/api/mapApi.ts
+++ b/src/api/mapApi.ts
@@ -1,6 +1,6 @@
 import instance from './instance';
 import type { ApiResponse } from '../types/api';
-import type { CultureEvent } from '../types/map';
+import type { AlternativeLocation, CultureEvent } from '../types/map';
 
 export const fetchCultureEvents = async (
   latitude: number,
@@ -11,5 +11,16 @@ export const fetchCultureEvents = async (
     params: { latitude, longitude },
     signal,
   });
+  return res.data.data;
+};
+
+export const fetchAlternativeLocations = async (
+  areaCode: string,
+  signal?: AbortSignal,
+): Promise<AlternativeLocation[]> => {
+  const res = await instance.get<ApiResponse<AlternativeLocation[]>>(
+    '/api/map/alternative-location',
+    { params: { areaCode }, signal },
+  );
   return res.data.data;
 };

--- a/src/components/map/AlternativeLocationBanner.tsx
+++ b/src/components/map/AlternativeLocationBanner.tsx
@@ -1,0 +1,30 @@
+import { Sparkles, X } from 'lucide-react';
+
+interface Props {
+  sourceName: string;
+  count: number;
+  onClose: () => void;
+}
+
+const AlternativeLocationBanner = ({ sourceName, count, onClose }: Props) => {
+  return (
+    <div className="absolute top-20 left-1/2 -translate-x-1/2 z-9999 flex items-center gap-3 bg-white rounded-full px-3 py-2 shadow-md whitespace-nowrap">
+      <div className="flex items-center gap-2 pl-2 text-sm text-gray-700">
+        <Sparkles size={14} className="text-blue-500 shrink-0" />
+        <span>
+          {sourceName}의 대체지역 <span className="text-blue-500 font-bold">{count}곳</span>
+        </span>
+      </div>
+      <div className="w-px h-5 bg-gray-200 shrink-0" />
+      <button
+        onClick={onClose}
+        className="cursor-pointer flex items-center gap-1.5 px-4 py-1.5 bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium rounded-full transition-colors"
+      >
+        <X size={13} />
+        끄기
+      </button>
+    </div>
+  );
+};
+
+export default AlternativeLocationBanner;

--- a/src/components/map/AlternativeMarker.tsx
+++ b/src/components/map/AlternativeMarker.tsx
@@ -1,0 +1,41 @@
+import { useNavigate } from 'react-router-dom';
+import { CustomOverlayMap } from 'react-kakao-maps-sdk';
+import {
+  CONGESTION_COLORS,
+  CONGESTION_LEVEL_MAP,
+  CONGESTION_COLOR_UNKNOWN,
+} from '../../types/congestion';
+import MarkerPin from './MarkerPin';
+import MarkerLabel from './MarkerLabel';
+import { calcMarkerSize } from './markerUtils';
+import type { AlternativeLocation } from '../../types/map';
+
+interface Props {
+  location: AlternativeLocation;
+  level: number;
+}
+
+const AlternativeMarker = ({ location, level }: Props) => {
+  const navigate = useNavigate();
+  const congestionLevel = CONGESTION_LEVEL_MAP[location.congestionLevel];
+  const color = congestionLevel ? CONGESTION_COLORS[congestionLevel] : CONGESTION_COLOR_UNKNOWN;
+  const position = { lat: location.latitude, lng: location.longitude };
+  const size = calcMarkerSize(level);
+
+  return (
+    <CustomOverlayMap position={position} yAnchor={1}>
+      <div
+        className="cursor-pointer flex flex-col items-center hover:scale-110 active:scale-95 transition-transform"
+        style={{ filter: 'drop-shadow(0 3px 8px rgba(0,0,0,0.3))' }}
+        onClick={() => navigate(`/place/${location.areaCode}`)}
+      >
+        <MarkerPin color={color} size={size} />
+        <div className="mt-1.5">
+          <MarkerLabel color={color} name={location.locationName} size={size} />
+        </div>
+      </div>
+    </CustomOverlayMap>
+  );
+};
+
+export default AlternativeMarker;

--- a/src/components/map/CongestionMarker.tsx
+++ b/src/components/map/CongestionMarker.tsx
@@ -1,26 +1,33 @@
-import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { CustomOverlayMap } from 'react-kakao-maps-sdk';
-import { MapPin, X } from 'lucide-react';
+import { X } from 'lucide-react';
 import { CONGESTION_COLORS, CONGESTION_LABELS } from '../../types/congestion';
 import { CATEGORY_NAMES } from '../../data/categories';
+import MarkerPin from './MarkerPin';
+import { calcMarkerSize } from './markerUtils';
 import type { PlaceMarker } from '../../types/congestion';
 
 interface CongestionMarkerProps {
   marker: PlaceMarker;
   level: number;
+  isOpen: boolean;
+  onOpen: () => void;
+  onClose: () => void;
+  onAlternativeRequest: (marker: PlaceMarker) => void;
 }
 
-const BASE_LEVEL = 7;
-const BASE_SIZE = 32;
-
-const CongestionMarker = ({ marker, level }: CongestionMarkerProps) => {
-  const [isOpen, setIsOpen] = useState(false);
+const CongestionMarker = ({
+  marker,
+  level,
+  isOpen,
+  onOpen,
+  onClose,
+  onAlternativeRequest,
+}: CongestionMarkerProps) => {
   const navigate = useNavigate();
   const color = CONGESTION_COLORS[marker.congestionLevel];
   const position = { lat: marker.latitude, lng: marker.longitude };
-  const scale = Math.max(0.5, Math.min(2.5, 1 + (BASE_LEVEL - level) * 0.2));
-  const size = Math.round(BASE_SIZE * scale);
+  const size = calcMarkerSize(level);
   const avgPeople = Math.round((marker.minPeopleCount + marker.maxPeopleCount) / 2);
 
   return (
@@ -30,24 +37,9 @@ const CongestionMarker = ({ marker, level }: CongestionMarkerProps) => {
           <div
             className="cursor-pointer flex flex-col items-center hover:scale-110 active:scale-95 transition-transform"
             style={{ filter: 'drop-shadow(0 3px 8px rgba(0,0,0,0.3))' }}
-            onClick={() => setIsOpen(true)}
+            onClick={onOpen}
           >
-            <div
-              className="flex items-center justify-center rounded-full border-[3px] border-white"
-              style={{ backgroundColor: color, width: size * 0.85, height: size * 0.85 }}
-            >
-              <MapPin size={size * 0.38} color="white" strokeWidth={2.5} />
-            </div>
-            <div
-              className="-mt-px"
-              style={{
-                width: 0,
-                height: 0,
-                borderLeft: `${size * 0.15}px solid transparent`,
-                borderRight: `${size * 0.15}px solid transparent`,
-                borderTop: `${size * 0.35}px solid ${color}`,
-              }}
-            />
+            <MarkerPin color={color} size={size} />
           </div>
         </CustomOverlayMap>
       )}
@@ -62,7 +54,7 @@ const CongestionMarker = ({ marker, level }: CongestionMarkerProps) => {
               <div className="flex items-start justify-between mb-1.5">
                 <p className="font-bold text-gray-900 text-sm">{marker.name}</p>
                 <button
-                  onClick={() => setIsOpen(false)}
+                  onClick={onClose}
                   className="cursor-pointer text-gray-400 hover:text-gray-600 ml-2 shrink-0"
                 >
                   <X size={14} />
@@ -95,10 +87,10 @@ const CongestionMarker = ({ marker, level }: CongestionMarkerProps) => {
 
               <div className="flex flex-col gap-1.5">
                 <button
-                  disabled
-                  className="w-full py-2 rounded-xl bg-gray-100 text-gray-400 text-xs font-semibold cursor-not-allowed"
+                  onClick={() => onAlternativeRequest(marker)}
+                  className="cursor-pointer w-full py-2 rounded-xl bg-blue-50 hover:bg-blue-100 text-blue-600 text-xs font-semibold transition-colors"
                 >
-                  대체지역 추천 (준비 중)
+                  대체지역 추천
                 </button>
                 <button
                   onClick={() => navigate(`/place/${marker.areaCode}`, { state: { marker } })}

--- a/src/components/map/KakaoMap.tsx
+++ b/src/components/map/KakaoMap.tsx
@@ -1,18 +1,33 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect, useRef } from 'react';
 import { Map } from 'react-kakao-maps-sdk';
 import { useCongestionMarkers } from '../../hooks/useCongestionMarkers';
 import CongestionMarker from './CongestionMarker';
+import AlternativeMarker from './AlternativeMarker';
+import SourceMarker from './SourceMarker';
+import type { AlternativeLocation } from '../../types/map';
+import type { PlaceMarker } from '../../types/congestion';
 
 const DEFAULT_CENTER = { lat: 37.5665, lng: 126.978 };
 const DEFAULT_LEVEL = 7;
 
 interface KakaoMapProps {
   selectedCategory: string;
+  alternativeLocations: AlternativeLocation[];
+  sourceMarker: PlaceMarker | null;
+  onAlternativeRequest: (marker: PlaceMarker) => void;
 }
 
-const KakaoMap = ({ selectedCategory }: KakaoMapProps) => {
+const KakaoMap = ({
+  selectedCategory,
+  alternativeLocations,
+  sourceMarker,
+  onAlternativeRequest,
+}: KakaoMapProps) => {
   const markers = useCongestionMarkers();
   const [level, setLevel] = useState(DEFAULT_LEVEL);
+  const [openMarkerId, setOpenMarkerId] = useState<string | null>(null);
+  const mapRef = useRef<kakao.maps.Map | null>(null);
+  const savedViewRef = useRef<{ center: kakao.maps.LatLng; level: number } | null>(null);
 
   const filtered = useMemo(
     () =>
@@ -20,15 +35,58 @@ const KakaoMap = ({ selectedCategory }: KakaoMapProps) => {
     [markers, selectedCategory],
   );
 
+  useEffect(() => {
+    if (!mapRef.current) return;
+
+    if (alternativeLocations.length === 0) {
+      if (savedViewRef.current) {
+        mapRef.current.setCenter(savedViewRef.current.center);
+        mapRef.current.setLevel(savedViewRef.current.level, { animate: true });
+        savedViewRef.current = null;
+      }
+      return;
+    }
+
+    savedViewRef.current = {
+      center: mapRef.current.getCenter(),
+      level: mapRef.current.getLevel(),
+    };
+
+    const bounds = new window.kakao.maps.LatLngBounds();
+    if (sourceMarker) {
+      bounds.extend(new window.kakao.maps.LatLng(sourceMarker.latitude, sourceMarker.longitude));
+    }
+    alternativeLocations.forEach((loc) => {
+      bounds.extend(new window.kakao.maps.LatLng(loc.latitude, loc.longitude));
+    });
+    mapRef.current.setBounds(bounds, 80);
+  }, [alternativeLocations, sourceMarker]);
+
   return (
     <Map
       center={DEFAULT_CENTER}
       style={{ width: '100%', height: '100%' }}
       level={level}
+      onCreate={(map) => {
+        mapRef.current = map;
+      }}
       onZoomChanged={(map) => setLevel(map.getLevel())}
     >
-      {filtered.map((marker) => (
-        <CongestionMarker key={marker.areaCode} marker={marker} level={level} />
+      {alternativeLocations.length === 0 &&
+        filtered.map((marker) => (
+          <CongestionMarker
+            key={marker.areaCode}
+            marker={marker}
+            level={level}
+            isOpen={openMarkerId === marker.areaCode}
+            onOpen={() => setOpenMarkerId(marker.areaCode)}
+            onClose={() => setOpenMarkerId(null)}
+            onAlternativeRequest={onAlternativeRequest}
+          />
+        ))}
+      {sourceMarker && <SourceMarker marker={sourceMarker} level={level} />}
+      {alternativeLocations.map((loc) => (
+        <AlternativeMarker key={loc.areaCode} location={loc} level={level} />
       ))}
     </Map>
   );

--- a/src/components/map/KakaoMap.tsx
+++ b/src/components/map/KakaoMap.tsx
@@ -47,10 +47,12 @@ const KakaoMap = ({
       return;
     }
 
-    savedViewRef.current = {
-      center: mapRef.current.getCenter(),
-      level: mapRef.current.getLevel(),
-    };
+    if (!savedViewRef.current) {
+      savedViewRef.current = {
+        center: mapRef.current.getCenter(),
+        level: mapRef.current.getLevel(),
+      };
+    }
 
     const bounds = new window.kakao.maps.LatLngBounds();
     if (sourceMarker) {

--- a/src/components/map/MarkerLabel.tsx
+++ b/src/components/map/MarkerLabel.tsx
@@ -1,0 +1,17 @@
+interface MarkerLabelProps {
+  color: string;
+  name: string;
+  size: number;
+}
+
+const MarkerLabel = ({ color, name, size }: MarkerLabelProps) => (
+  <div
+    className="flex items-center gap-1.5 bg-white rounded-full px-2.5 py-1 shadow-md whitespace-nowrap"
+    style={{ fontSize: `${Math.max(10, size * 0.28)}px` }}
+  >
+    <div className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: color }} />
+    <span className="font-semibold text-gray-800">{name}</span>
+  </div>
+);
+
+export default MarkerLabel;

--- a/src/components/map/MarkerPin.tsx
+++ b/src/components/map/MarkerPin.tsx
@@ -1,0 +1,29 @@
+import { MapPin } from 'lucide-react';
+
+interface MarkerPinProps {
+  color: string;
+  size: number;
+}
+
+const MarkerPin = ({ color, size }: MarkerPinProps) => (
+  <>
+    <div
+      className="flex items-center justify-center rounded-full border-[3px] border-white"
+      style={{ backgroundColor: color, width: size * 0.85, height: size * 0.85 }}
+    >
+      <MapPin size={size * 0.38} color="white" strokeWidth={2.5} />
+    </div>
+    <div
+      className="-mt-px"
+      style={{
+        width: 0,
+        height: 0,
+        borderLeft: `${size * 0.15}px solid transparent`,
+        borderRight: `${size * 0.15}px solid transparent`,
+        borderTop: `${size * 0.35}px solid ${color}`,
+      }}
+    />
+  </>
+);
+
+export default MarkerPin;

--- a/src/components/map/SourceMarker.tsx
+++ b/src/components/map/SourceMarker.tsx
@@ -1,0 +1,52 @@
+import { useNavigate } from 'react-router-dom';
+import { CustomOverlayMap } from 'react-kakao-maps-sdk';
+import { CONGESTION_COLORS } from '../../types/congestion';
+import MarkerPin from './MarkerPin';
+import MarkerLabel from './MarkerLabel';
+import { calcMarkerSize } from './markerUtils';
+import type { PlaceMarker } from '../../types/congestion';
+
+interface Props {
+  marker: PlaceMarker;
+  level: number;
+}
+
+const SourceMarker = ({ marker, level }: Props) => {
+  const navigate = useNavigate();
+  const color = CONGESTION_COLORS[marker.congestionLevel];
+  const position = { lat: marker.latitude, lng: marker.longitude };
+  const size = calcMarkerSize(level);
+
+  return (
+    <CustomOverlayMap position={position} yAnchor={1} zIndex={5}>
+      <div
+        className="cursor-pointer flex flex-col items-center hover:scale-110 active:scale-95 transition-transform"
+        style={{ filter: 'drop-shadow(0 3px 8px rgba(0,0,0,0.4))' }}
+        onClick={() => navigate(`/place/${marker.areaCode}`, { state: { marker } })}
+      >
+        <div className="relative flex flex-col items-center">
+          <div
+            className="absolute animate-ping rounded-full opacity-20"
+            style={{
+              backgroundColor: color,
+              width: size * 0.85 + 12,
+              height: size * 0.85 + 12,
+              top: -6,
+              left: '50%',
+              transform: 'translateX(-50%)',
+            }}
+          />
+          <MarkerPin color={color} size={size} />
+        </div>
+        <div className="mt-1.5 flex flex-col items-center gap-1">
+          <span className="text-[9px] text-white font-bold rounded-full px-2 py-0.5 bg-gray-700 whitespace-nowrap">
+            선택한 장소
+          </span>
+          <MarkerLabel color={color} name={marker.name} size={size} />
+        </div>
+      </div>
+    </CustomOverlayMap>
+  );
+};
+
+export default SourceMarker;

--- a/src/components/map/markerUtils.ts
+++ b/src/components/map/markerUtils.ts
@@ -1,0 +1,5 @@
+const BASE_LEVEL = 7;
+const BASE_SIZE = 32;
+
+export const calcMarkerSize = (level: number) =>
+  Math.round(BASE_SIZE * Math.max(0.5, Math.min(2.5, 1 + (BASE_LEVEL - level) * 0.2)));

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import KakaoMap from '../components/map/KakaoMap';
 import Header from '../components/layout/Header';
 import CategoryFilter from '../components/filter/CategoryFilter';
@@ -18,10 +18,16 @@ type AlternativeState = {
 const HomePage = () => {
   const [selectedCategory, setSelectedCategory] = useState('all');
   const [alternativeState, setAlternativeState] = useState<AlternativeState>(null);
+  const abortRef = useRef<AbortController | null>(null);
 
   const handleAlternativeRequest = useCallback(async (sourceMarker: PlaceMarker) => {
-    const locations = await fetchAlternativeLocations(sourceMarker.areaCode).catch(() => []);
-    setAlternativeState({ sourceMarker, locations });
+    abortRef.current?.abort();
+    abortRef.current = new AbortController();
+
+    const locations = await fetchAlternativeLocations(sourceMarker.areaCode, abortRef.current.signal).catch(() => []);
+    if (locations.length > 0) {
+      setAlternativeState({ sourceMarker, locations });
+    }
   }, []);
 
   const handleAlternativeClose = useCallback(() => {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,25 +1,55 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import KakaoMap from '../components/map/KakaoMap';
 import Header from '../components/layout/Header';
 import CategoryFilter from '../components/filter/CategoryFilter';
 import MapControls from '../components/map/MapControls';
 import CongestionLegend from '../components/congestion/CongestionLegend';
 import CongestionRankCard from '../components/congestion/CongestionRankCard';
+import AlternativeLocationBanner from '../components/map/AlternativeLocationBanner';
+import { fetchAlternativeLocations } from '../api/mapApi';
+import type { AlternativeLocation } from '../types/map';
+import type { PlaceMarker } from '../types/congestion';
 
+type AlternativeState = {
+  sourceMarker: PlaceMarker;
+  locations: AlternativeLocation[];
+} | null;
 
 const HomePage = () => {
   const [selectedCategory, setSelectedCategory] = useState('all');
+  const [alternativeState, setAlternativeState] = useState<AlternativeState>(null);
+
+  const handleAlternativeRequest = useCallback(async (sourceMarker: PlaceMarker) => {
+    const locations = await fetchAlternativeLocations(sourceMarker.areaCode).catch(() => []);
+    setAlternativeState({ sourceMarker, locations });
+  }, []);
+
+  const handleAlternativeClose = useCallback(() => {
+    setAlternativeState(null);
+  }, []);
 
   return (
     <div className="flex flex-col w-full h-dvh">
       <Header />
       <div className="relative flex-1 overflow-hidden">
-        <KakaoMap selectedCategory={selectedCategory} />
+        <KakaoMap
+          selectedCategory={selectedCategory}
+          alternativeLocations={alternativeState?.locations ?? []}
+          sourceMarker={alternativeState?.sourceMarker ?? null}
+          onAlternativeRequest={handleAlternativeRequest}
+        />
+        {alternativeState && (
+          <AlternativeLocationBanner
+            sourceName={alternativeState.sourceMarker.name}
+            count={alternativeState.locations.length}
+            onClose={handleAlternativeClose}
+          />
+        )}
         <CategoryFilter selected={selectedCategory} onSelect={setSelectedCategory} />
         <MapControls onZoomIn={() => {}} onZoomOut={() => {}} onLocate={() => {}} />
         <CongestionLegend />
         <CongestionRankCard type="busiest" initialRatio={{ x: 1, y: 0.13 }} />
-        <CongestionRankCard type="relaxed" initialRatio={{ x: 1, y: 0.40 }} />
+        <CongestionRankCard type="relaxed" initialRatio={{ x: 1, y: 0.4 }} />
       </div>
     </div>
   );

--- a/src/types/congestion.ts
+++ b/src/types/congestion.ts
@@ -23,6 +23,8 @@ export const CONGESTION_COLORS: Record<CongestionLevel, string> = {
   CROWDED: '#ef4444', // red-500
 };
 
+export const CONGESTION_COLOR_UNKNOWN = '#9ca3af'; // gray-400, 혼잡도 미확인 상태
+
 export interface ForecastItem {
   forecastTime: string;
   congestionLevel: string;

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -1,3 +1,12 @@
+export interface AlternativeLocation {
+  areaCode: string;
+  locationName: string;
+  latitude: number;
+  longitude: number;
+  priority: number;
+  congestionLevel: string;
+}
+
 export interface CultureEvent {
   title: string;
   place: string;


### PR DESCRIPTION
## 관려 이슈
Closes #37 

## 작업 내용

혼잡한 장소의 팝업에서 대체지역 추천 버튼을 누르면 지도에 대체지역 마커들이 표시되는 뷰를 구현했습니다.

### 주요 변경사항

- 대체지역 마커(`AlternativeMarker`): 혼잡도 색상 dot + 흰 배경 pill 라벨
- 선택 장소 마커(`SourceMarker`): pulsing ring 애니메이션 + "선택한 장소" 태그로 원래 목적지 구분
- 배너(`AlternativeLocationBanner`): 대체지역 수 표시 및 끄기 버튼
- 자동 줌: 선택 장소 + 대체지역 전체를 `setBounds`로 화면에 맞춤
- 끄기 버튼: 이전 지도 중심·줌 레벨·마커 팝업 상태까지 복원

### 리팩터링

- `MarkerPin` / `MarkerLabel` / `markerUtils`로 마커 핀·라벨 공통 컴포넌트 추출
- `CongestionMarker` 팝업 open 상태를 `KakaoMap`으로 이전해 대체지역 뷰 전환 시 팝업 상태 유지

## 스크린샷
<img width="1277" height="695" alt="image" src="https://github.com/user-attachments/assets/36e40d3b-6fc6-45de-8173-c97970f129f9" />


