### PR TITLE
feat: 홈 지도 컨트롤, 검색 기능 구현 및 혼잡도 카드 개선

### DIFF
--- a/src/components/congestion/CongestionRankCard.tsx
+++ b/src/components/congestion/CongestionRankCard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { TrendingUp, TrendingDown, ArrowRight } from 'lucide-react';
+import { TrendingUp, TrendingDown, ArrowRight, GripVertical } from 'lucide-react';
 import axios from 'axios';
 import { fetchBusiestRanking, fetchRelaxedRanking } from '../../api/congestionApi';
 import { CONGESTION_LEVEL_MAP, CONGESTION_COLORS, CONGESTION_LABELS } from '../../types/congestion';
@@ -44,7 +44,7 @@ const CongestionRankCard = ({ type, initialRatio }: Props) => {
     <div
       ref={ref}
       onMouseDown={handleMouseDown}
-      className="fixed z-10 bg-white rounded-2xl shadow-2xl border border-gray-200 p-5 w-[16vw] min-w-56 max-w-80 select-none"
+      className="rank-card-hint fixed z-10 bg-white rounded-2xl shadow-2xl border border-gray-200 p-5 w-[16vw] min-w-56 max-w-80 select-none"
       style={{
         left: 0,
         top: 0,
@@ -56,6 +56,7 @@ const CongestionRankCard = ({ type, initialRatio }: Props) => {
       <div className="flex items-center gap-2 mb-4">
         <Icon size={16} className={iconColor} />
         <span className="text-base font-bold text-gray-900">{title}</span>
+        <GripVertical size={16} className="ml-auto text-gray-300" aria-hidden />
       </div>
 
       {loading ? (

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { MapPin, Search, Bell, Menu, X } from 'lucide-react';
+import { MapPin, Bell, Menu, X } from 'lucide-react';
+import HomeSearch from './HomeSearch';
 
 const NAV_LINKS = [
   { label: 'Live Map', path: '/' },
@@ -8,7 +9,11 @@ const NAV_LINKS = [
   { label: 'Route Planner', path: '/route' },
 ];
 
-const Header = () => {
+interface HeaderProps {
+  onSearchSelect?: (areaCode: string) => void;
+}
+
+const Header = ({ onSearchSelect }: HeaderProps) => {
   const location = useLocation();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
@@ -40,15 +45,10 @@ const Header = () => {
 
         {/* 우측 영역 */}
         <div className="flex items-center gap-2 sm:gap-4">
-          {/* 검색 (데스크탑) */}
-          <div className="hidden lg:flex items-center gap-2 bg-gray-100 rounded-lg px-4 py-2 w-48 xl:w-64">
-            <Search className="size-4 text-gray-400 shrink-0" />
-            <input
-              type="text"
-              placeholder="Search hotspots..."
-              className="bg-transparent outline-none text-sm w-full"
-            />
-          </div>
+          {/* 검색 (홈, 데스크탑) */}
+          {location.pathname === '/' && onSearchSelect && (
+            <HomeSearch onSelect={onSearchSelect} />
+          )}
 
           {/* 아이콘 (데스크탑) */}
           <button className="hidden sm:flex p-2 hover:bg-gray-100 rounded-lg transition-colors">

--- a/src/components/layout/HomeSearch.tsx
+++ b/src/components/layout/HomeSearch.tsx
@@ -1,0 +1,80 @@
+import { useMemo, useState } from 'react';
+import { Search } from 'lucide-react';
+import { searchLocationsByName } from '../../data/locations';
+
+interface Props {
+  onSelect: (areaCode: string) => void;
+}
+
+const MAX_RESULTS = 8;
+
+const HomeSearch = ({ onSelect }: Props) => {
+  const [value, setValue] = useState('');
+  const [open, setOpen] = useState(false);
+
+  const results = useMemo(() => {
+    if (!value.trim()) return [];
+    return searchLocationsByName(value).slice(0, MAX_RESULTS);
+  }, [value]);
+
+  const handleSelect = (areaCode: string) => {
+    onSelect(areaCode);
+    setValue('');
+    setOpen(false);
+  };
+
+  return (
+    <div className="hidden lg:block relative">
+      <div className="flex items-center gap-2 bg-gray-100 rounded-lg px-4 py-2 w-48 xl:w-64">
+        <Search className="size-4 text-gray-400 shrink-0" />
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => {
+            setValue(e.target.value);
+            setOpen(true);
+          }}
+          onFocus={() => setOpen(true)}
+          onBlur={() => setOpen(false)}
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') {
+              setOpen(false);
+              return;
+            }
+            if (e.key === 'Enter' && !e.nativeEvent.isComposing && results.length > 0) {
+              handleSelect(results[0].areaCode);
+            }
+          }}
+          placeholder="장소 검색..."
+          aria-label="장소 검색"
+          className="bg-transparent outline-none text-sm w-full"
+        />
+      </div>
+
+      {open && value.trim() && (
+        <div className="absolute top-full left-0 right-0 mt-1 bg-white rounded-lg shadow-lg border border-gray-100 overflow-hidden">
+          {results.length > 0 ? (
+            <ul className="py-1 max-h-72 overflow-y-auto">
+              {results.map((loc) => (
+                <li key={loc.areaCode}>
+                  <button
+                    type="button"
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={() => handleSelect(loc.areaCode)}
+                    className="cursor-pointer w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition-colors"
+                  >
+                    {loc.name}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className="px-4 py-3 text-sm text-gray-400">검색 결과가 없어요</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default HomeSearch;

--- a/src/components/map/CongestionMarker.tsx
+++ b/src/components/map/CongestionMarker.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { CustomOverlayMap } from 'react-kakao-maps-sdk';
 import { X } from 'lucide-react';
@@ -14,6 +15,7 @@ interface CongestionMarkerProps {
   onOpen: () => void;
   onClose: () => void;
   onAlternativeRequest: (marker: PlaceMarker) => void;
+  bounceNonce?: number | null;
 }
 
 const CongestionMarker = ({
@@ -23,6 +25,7 @@ const CongestionMarker = ({
   onOpen,
   onClose,
   onAlternativeRequest,
+  bounceNonce,
 }: CongestionMarkerProps) => {
   const navigate = useNavigate();
   const color = CONGESTION_COLORS[marker.congestionLevel];
@@ -30,14 +33,21 @@ const CongestionMarker = ({
   const size = calcMarkerSize(level);
   const avgPeople = Math.round((marker.minPeopleCount + marker.maxPeopleCount) / 2);
 
+  // 검색 선택 시 한 번만 튀도록: 애니메이션을 끝낸 nonce를 기록해 그 외 리렌더(줌 등)에서는 재생 안 함
+  const [finishedNonce, setFinishedNonce] = useState<number | null>(null);
+  const shouldBounce = bounceNonce != null && bounceNonce !== finishedNonce;
+
   return (
     <>
       {!isOpen && (
         <CustomOverlayMap position={position} yAnchor={1}>
           <div
-            className="cursor-pointer flex flex-col items-center hover:scale-110 active:scale-95 transition-transform"
+            className={`cursor-pointer flex flex-col items-center hover:scale-110 active:scale-95 transition-transform ${
+              shouldBounce ? 'marker-bounce' : ''
+            }`}
             style={{ filter: 'drop-shadow(0 3px 8px rgba(0,0,0,0.3))' }}
             onClick={onOpen}
+            onAnimationEnd={() => setFinishedNonce(bounceNonce ?? null)}
           >
             <MarkerPin color={color} size={size} />
           </div>

--- a/src/components/map/CurrentLocationMarker.tsx
+++ b/src/components/map/CurrentLocationMarker.tsx
@@ -1,0 +1,30 @@
+import { CustomOverlayMap } from 'react-kakao-maps-sdk';
+
+interface Props {
+  latitude: number;
+  longitude: number;
+}
+
+const COLOR = '#3b82f6';
+
+const CurrentLocationMarker = ({ latitude, longitude }: Props) => (
+  <CustomOverlayMap position={{ lat: latitude, lng: longitude }} yAnchor={0.5} zIndex={6}>
+    <div className="relative flex items-center justify-center">
+      <span
+        className="absolute animate-ping rounded-full opacity-30"
+        style={{ backgroundColor: COLOR, width: 28, height: 28 }}
+      />
+      <span
+        className="rounded-full border-2 border-white"
+        style={{
+          backgroundColor: COLOR,
+          width: 16,
+          height: 16,
+          boxShadow: '0 1px 4px rgba(0,0,0,0.4)',
+        }}
+      />
+    </div>
+  </CustomOverlayMap>
+);
+
+export default CurrentLocationMarker;

--- a/src/components/map/KakaoMap.tsx
+++ b/src/components/map/KakaoMap.tsx
@@ -4,6 +4,7 @@ import { useCongestionMarkers } from '../../hooks/useCongestionMarkers';
 import CongestionMarker from './CongestionMarker';
 import AlternativeMarker from './AlternativeMarker';
 import SourceMarker from './SourceMarker';
+import CurrentLocationMarker from './CurrentLocationMarker';
 import type { AlternativeLocation } from '../../types/map';
 import type { PlaceMarker } from '../../types/congestion';
 
@@ -15,6 +16,9 @@ interface KakaoMapProps {
   alternativeLocations: AlternativeLocation[];
   sourceMarker: PlaceMarker | null;
   onAlternativeRequest: (marker: PlaceMarker) => void;
+  onMapReady?: (map: kakao.maps.Map) => void;
+  userLocation?: { lat: number; lng: number } | null;
+  bounceTarget?: { areaCode: string; nonce: number } | null;
 }
 
 const KakaoMap = ({
@@ -22,6 +26,9 @@ const KakaoMap = ({
   alternativeLocations,
   sourceMarker,
   onAlternativeRequest,
+  onMapReady,
+  userLocation,
+  bounceTarget,
 }: KakaoMapProps) => {
   const markers = useCongestionMarkers();
   const [level, setLevel] = useState(DEFAULT_LEVEL);
@@ -71,6 +78,7 @@ const KakaoMap = ({
       level={level}
       onCreate={(map) => {
         mapRef.current = map;
+        onMapReady?.(map);
       }}
       onZoomChanged={(map) => setLevel(map.getLevel())}
     >
@@ -84,9 +92,13 @@ const KakaoMap = ({
             onOpen={() => setOpenMarkerId(marker.areaCode)}
             onClose={() => setOpenMarkerId(null)}
             onAlternativeRequest={onAlternativeRequest}
+            bounceNonce={bounceTarget?.areaCode === marker.areaCode ? bounceTarget.nonce : null}
           />
         ))}
       {sourceMarker && <SourceMarker marker={sourceMarker} level={level} />}
+      {userLocation && (
+        <CurrentLocationMarker latitude={userLocation.lat} longitude={userLocation.lng} />
+      )}
       {alternativeLocations.map((loc) => (
         <AlternativeMarker key={loc.areaCode} location={loc} level={level} />
       ))}

--- a/src/components/map/MapControls.tsx
+++ b/src/components/map/MapControls.tsx
@@ -12,21 +12,21 @@ const MapControls = ({ onZoomIn, onZoomOut, onLocate }: MapControlsProps) => {
       <button
         onClick={onZoomIn}
         aria-label="확대"
-        className="w-10 h-10 bg-white rounded-lg shadow-md flex items-center justify-center text-gray-700 hover:bg-gray-50"
+        className="cursor-pointer w-10 h-10 bg-white rounded-lg shadow-md flex items-center justify-center text-gray-700 hover:bg-gray-50"
       >
         <Plus size={18} />
       </button>
       <button
         onClick={onZoomOut}
         aria-label="축소"
-        className="w-10 h-10 bg-white rounded-lg shadow-md flex items-center justify-center text-gray-700 hover:bg-gray-50"
+        className="cursor-pointer w-10 h-10 bg-white rounded-lg shadow-md flex items-center justify-center text-gray-700 hover:bg-gray-50"
       >
         <Minus size={18} />
       </button>
       <button
         onClick={onLocate}
         aria-label="내 위치 찾기"
-        className="w-10 h-10 bg-blue-500 rounded-lg shadow-md flex items-center justify-center text-white hover:bg-blue-600"
+        className="cursor-pointer w-10 h-10 bg-blue-500 rounded-lg shadow-md flex items-center justify-center text-white hover:bg-blue-600"
       >
         <LocateFixed size={18} />
       </button>

--- a/src/data/locations.ts
+++ b/src/data/locations.ts
@@ -865,3 +865,9 @@ export const LOCATIONS: Location[] = [
 ];
 
 export const LOCATION_MAP = new Map<string, Location>(LOCATIONS.map((loc) => [loc.areaCode, loc]));
+
+// 이름 부분 일치(대소문자 무관) 검색. 빈 쿼리는 전체를 반환한다.
+export const searchLocationsByName = (query: string): Location[] => {
+  const q = query.trim().toLowerCase();
+  return LOCATIONS.filter((loc) => loc.name.toLowerCase().includes(q));
+};

--- a/src/hooks/useHotspotsFilter.ts
+++ b/src/hooks/useHotspotsFilter.ts
@@ -1,5 +1,5 @@
 import { useSearchParams } from 'react-router-dom';
-import { LOCATIONS } from '../data/locations';
+import { searchLocationsByName } from '../data/locations';
 import type { LocationCategory } from '../data/locations';
 
 export type FilterCategory = LocationCategory | 'all';
@@ -33,11 +33,9 @@ export function useHotspotsFilter(searchValue: string) {
     : 'all';
   const pageParam = parseInt(searchParams.get('page') ?? '1', 10);
 
-  const filtered = LOCATIONS.filter((loc) => {
-    const matchesQuery = loc.name.toLowerCase().includes(searchValue.toLowerCase());
-    const matchesCategory = activeCategory === 'all' || loc.category === activeCategory;
-    return matchesQuery && matchesCategory;
-  });
+  const filtered = searchLocationsByName(searchValue).filter(
+    (loc) => activeCategory === 'all' || loc.category === activeCategory,
+  );
 
   const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
   const currentPage =

--- a/src/hooks/useMapControls.ts
+++ b/src/hooks/useMapControls.ts
@@ -1,0 +1,42 @@
+import { useCallback, useRef, useState } from 'react';
+
+const MIN_MAP_LEVEL = 1;
+const MAX_MAP_LEVEL = 14;
+
+// 카카오맵 인스턴스에 대한 명령형 제어(줌·현위치·이동)를 한곳에 모은 훅
+export const useMapControls = () => {
+  const mapRef = useRef<kakao.maps.Map | null>(null);
+  const [userLocation, setUserLocation] = useState<{ lat: number; lng: number } | null>(null);
+
+  const setMap = useCallback((map: kakao.maps.Map) => {
+    mapRef.current = map;
+  }, []);
+
+  const zoomIn = useCallback(() => {
+    const map = mapRef.current;
+    if (map) map.setLevel(Math.max(MIN_MAP_LEVEL, map.getLevel() - 1), { animate: true });
+  }, []);
+
+  const zoomOut = useCallback(() => {
+    const map = mapRef.current;
+    if (map) map.setLevel(Math.min(MAX_MAP_LEVEL, map.getLevel() + 1), { animate: true });
+  }, []);
+
+  const panTo = useCallback((lat: number, lng: number) => {
+    mapRef.current?.panTo(new window.kakao.maps.LatLng(lat, lng));
+  }, []);
+
+  const locate = useCallback(() => {
+    if (!navigator.geolocation) return;
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        const { latitude, longitude } = pos.coords;
+        setUserLocation({ lat: latitude, lng: longitude });
+        mapRef.current?.panTo(new window.kakao.maps.LatLng(latitude, longitude));
+      },
+      () => {},
+    );
+  }, []);
+
+  return { setMap, zoomIn, zoomOut, locate, panTo, userLocation };
+};

--- a/src/index.css
+++ b/src/index.css
@@ -11,3 +11,57 @@
     font-family: system-ui, -apple-system, sans-serif;
   }
 }
+
+/* 드래그 가능 카드: 등장 시 한 번 까딱이는 힌트 (translate 속성 사용 → inline transform과 충돌 없음) */
+@keyframes rank-card-hint {
+  0%,
+  100% {
+    translate: 0 0;
+  }
+  30% {
+    translate: 0 -7px;
+  }
+  60% {
+    translate: 0 -3px;
+  }
+}
+
+.rank-card-hint {
+  animation: rank-card-hint 0.7s ease-in-out 0.4s 1;
+}
+
+/* 검색으로 선택된 마커: 통통 튀는 강조 효과 */
+@keyframes marker-bounce {
+  0% {
+    translate: 0 0;
+  }
+  15% {
+    translate: 0 -16px;
+  }
+  30% {
+    translate: 0 0;
+  }
+  45% {
+    translate: 0 -9px;
+  }
+  60% {
+    translate: 0 0;
+  }
+  75% {
+    translate: 0 -4px;
+  }
+  100% {
+    translate: 0 0;
+  }
+}
+
+.marker-bounce {
+  animation: marker-bounce 0.9s ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rank-card-hint,
+  .marker-bounce {
+    animation: none;
+  }
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -8,6 +8,8 @@ import CongestionLegend from '../components/congestion/CongestionLegend';
 import CongestionRankCard from '../components/congestion/CongestionRankCard';
 import AlternativeLocationBanner from '../components/map/AlternativeLocationBanner';
 import { fetchAlternativeLocations } from '../api/mapApi';
+import { useMapControls } from '../hooks/useMapControls';
+import { LOCATION_MAP } from '../data/locations';
 import type { AlternativeLocation } from '../types/map';
 import type { PlaceMarker } from '../types/congestion';
 
@@ -19,7 +21,20 @@ type AlternativeState = {
 const HomePage = () => {
   const [selectedCategory, setSelectedCategory] = useState('all');
   const [alternativeState, setAlternativeState] = useState<AlternativeState>(null);
+  const [searchFocus, setSearchFocus] = useState<{ areaCode: string; nonce: number } | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const { setMap, zoomIn, zoomOut, locate, panTo, userLocation } = useMapControls();
+
+  const handleSearchSelect = useCallback(
+    (areaCode: string) => {
+      const loc = LOCATION_MAP.get(areaCode);
+      if (loc) panTo(loc.latitude, loc.longitude);
+      setSelectedCategory('all');
+      setAlternativeState(null);
+      setSearchFocus({ areaCode, nonce: Date.now() });
+    },
+    [panTo],
+  );
 
   const handleAlternativeRequest = useCallback(async (sourceMarker: PlaceMarker) => {
     abortRef.current?.abort();
@@ -45,13 +60,16 @@ const HomePage = () => {
 
   return (
     <div className="flex flex-col w-full h-dvh">
-      <Header />
+      <Header onSearchSelect={handleSearchSelect} />
       <div className="relative flex-1 overflow-hidden">
         <KakaoMap
           selectedCategory={selectedCategory}
           alternativeLocations={alternativeState?.locations ?? []}
           sourceMarker={alternativeState?.sourceMarker ?? null}
           onAlternativeRequest={handleAlternativeRequest}
+          onMapReady={setMap}
+          userLocation={userLocation}
+          bounceTarget={searchFocus}
         />
         {alternativeState && (
           <AlternativeLocationBanner
@@ -61,7 +79,7 @@ const HomePage = () => {
           />
         )}
         <CategoryFilter selected={selectedCategory} onSelect={setSelectedCategory} />
-        <MapControls onZoomIn={() => {}} onZoomOut={() => {}} onLocate={() => {}} />
+        <MapControls onZoomIn={zoomIn} onZoomOut={zoomOut} onLocate={locate} />
         <CongestionLegend />
         <CongestionRankCard type="busiest" initialRatio={{ x: 1, y: 0.13 }} />
         <CongestionRankCard type="relaxed" initialRatio={{ x: 1, y: 0.4 }} />


### PR DESCRIPTION
## 관련 이슈
#42 
## 변경 사항

### 지도 컨트롤
- 줌인/줌아웃/현위치 버튼 동작 구현 (기존 빈 핸들러 → `useMapControls` 훅)
- 현위치 버튼 클릭 시 해당 위치에 마커 표시

### 홈 검색
- 헤더 검색창을 홈 전용 실시간 드롭다운으로 구현
- 검색 결과 선택 시 지도가 해당 장소로 이동하며 마커 강조(bounce)

### 혼잡도 카드
- 드래그 가능 표시: 헤더 줄 그립 아이콘 + 등장 시 강조 애니메이션

### 리팩터링
- 카카오맵 명령형 제어를 `useMapControls` 훅으로 분리
- 장소 이름 검색 로직을 `searchLocationsByName` 공통 함수로 통일