### PR TITLE
feat: 상세페이지 AI 분석, 위치, 대체장소 구현 및 검색, 디자인 개선

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>단번에</title>
-    <script type="text/javascript" src="https://dapi.kakao.com/v2/maps/sdk.js?appkey=%VITE_KAKAO_MAP_KEY%"></script>
+    <!-- libraries=services: 좌표→주소 변환(kakao.maps.services.Geocoder) 사용을 위해 필요 -->
+    <script type="text/javascript" src="https://dapi.kakao.com/v2/maps/sdk.js?appkey=%VITE_KAKAO_MAP_KEY%&libraries=services"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,10 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@phosphor-icons/react": "^2.1.10",
         "axios": "^1.13.6",
         "lucide-react": "^1.7.0",
+        "pretendard": "^1.3.9",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-kakao-maps-sdk": "^1.2.1",
@@ -1025,6 +1027,19 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@phosphor-icons/react": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.10.tgz",
+      "integrity": "sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8",
+        "react-dom": ">= 16.8"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -3756,6 +3771,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretendard": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/pretendard/-/pretendard-1.3.9.tgz",
+      "integrity": "sha512-PaQAADyLY5v4kYFwkpSJHbSSYIkiriY/1xXw75TKoZ9UQQqeU+tvP05yTdZAWibiIYoo8ZKtRv8PM7w0IaywSw==",
+      "license": "OFL-1.1"
     },
     "node_modules/prettier": {
       "version": "3.8.1",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@phosphor-icons/react": "^2.1.10",
     "axios": "^1.13.6",
     "lucide-react": "^1.7.0",
+    "pretendard": "^1.3.9",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-kakao-maps-sdk": "^1.2.1",

--- a/src/api/congestionApi.ts
+++ b/src/api/congestionApi.ts
@@ -1,6 +1,10 @@
 import instance from './instance';
 import type { ApiResponse } from '../types/api';
-import type { CongestionData, CongestionRankingResponse } from '../types/congestion';
+import type {
+  AireportResponse,
+  CongestionData,
+  CongestionRankingResponse,
+} from '../types/congestion';
 
 export const fetchAllCongestion = async (): Promise<CongestionData[]> => {
   const res = await instance.get<ApiResponse<CongestionData[]>>('/api/congestion');
@@ -30,6 +34,17 @@ export const fetchRelaxedRanking = async (
   const res = await instance.get<ApiResponse<CongestionRankingResponse>>(
     '/api/congestion/analysis/ranking/relaxed',
     { params: { limit }, signal },
+  );
+  return res.data.data;
+};
+
+export const fetchAiReport = async (
+  areaCode: string,
+  signal?: AbortSignal,
+): Promise<AireportResponse> => {
+  const res = await instance.get<ApiResponse<AireportResponse>>(
+    `/api/congestion/${areaCode}/ai-report`,
+    { signal },
   );
   return res.data.data;
 };

--- a/src/components/congestion/CongestionLegend.tsx
+++ b/src/components/congestion/CongestionLegend.tsx
@@ -1,7 +1,7 @@
 const LEGEND = [
   { label: 'Q', fullLabel: 'QUIET', color: 'bg-green-500' },
-  { label: 'M', fullLabel: 'MODERATE', color: 'bg-orange-400' },
-  { label: 'B', fullLabel: 'BUSY', color: 'bg-yellow-400' },
+  { label: 'M', fullLabel: 'MODERATE', color: 'bg-yellow-400' },
+  { label: 'B', fullLabel: 'BUSY', color: 'bg-orange-400' },
   { label: 'C', fullLabel: 'CROWDED', color: 'bg-red-500' },
 ];
 

--- a/src/components/detail/AiInsightCard.tsx
+++ b/src/components/detail/AiInsightCard.tsx
@@ -1,0 +1,78 @@
+import { useAiReport } from '../../hooks/useAiReport';
+import { formatPopulationTime } from '../../utils/date';
+import SectionHeader from './SectionHeader';
+
+// AI 카드의 비-success 상태에서 표시할 메시지 — 한 곳에 모아 두면 톤 통일/번역 시 유리
+const AI_STATE_MESSAGES = {
+  empty: '혼잡한 시점에 AI 분석이 생성돼요.',
+  stale: '이 시간대의 AI 분석은 아직 준비되지 않았어요.',
+  error: 'AI 분석 정보를 불러올 수 없어요.',
+} as const;
+
+interface Props {
+  areaCode: string;
+}
+
+const PlaceholderCard = ({ message }: { message: string }) => (
+  <div className="bg-white rounded-2xl p-6 shadow-sm text-center text-slate-400 text-sm">
+    {message}
+  </div>
+);
+
+const AiInsightCard = ({ areaCode }: Props) => {
+  const state = useAiReport(areaCode);
+
+  return (
+    <div>
+      <SectionHeader title="AI가 본 혼잡 원인" className="mb-4" />
+      {state.status === 'loading' && (
+        <div className="bg-white rounded-2xl shadow-sm animate-pulse h-28" />
+      )}
+      {state.status === 'empty' && <PlaceholderCard message={AI_STATE_MESSAGES.empty} />}
+      {state.status === 'stale' && <PlaceholderCard message={AI_STATE_MESSAGES.stale} />}
+      {state.status === 'error' && <PlaceholderCard message={AI_STATE_MESSAGES.error} />}
+      {state.status === 'success' && (
+        <div className="relative overflow-hidden rounded-2xl shadow-sm border border-slate-100 bg-white px-8 sm:px-12 py-10 sm:py-12">
+          <div
+            className="pointer-events-none absolute -top-24 -right-24 w-72 h-72 rounded-full bg-gradient-to-br from-blue-300/25 to-blue-100/10 blur-3xl"
+            aria-hidden
+          />
+
+          <span
+            className="pointer-events-none select-none absolute -left-2 -top-8 text-[140px] font-extrabold text-blue-100 leading-none"
+            aria-hidden
+          >
+            &ldquo;
+          </span>
+
+          <div className="relative">
+            <div className="flex items-center justify-end mb-7">
+              <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-green-50 border border-green-100/70">
+                <span className="relative flex h-1.5 w-1.5">
+                  <span className="absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75 animate-ping" />
+                  <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-green-500" />
+                </span>
+                <span className="text-[9px] font-bold tracking-[0.22em] text-green-700 uppercase">
+                  Live
+                </span>
+              </span>
+            </div>
+
+            <p className="text-xl sm:text-2xl font-bold text-slate-900 leading-[1.55] tracking-[-0.02em] whitespace-pre-line">
+              {state.data.analysisMessage}
+            </p>
+
+            {state.data.populationTime && (
+              <p className="mt-8 text-xs text-slate-400 tracking-wide leading-relaxed">
+                {formatPopulationTime(state.data.populationTime)} 측정 데이터를 기반으로 분석한
+                결과예요
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AiInsightCard;

--- a/src/components/detail/AlternativePlacesSidebar.tsx
+++ b/src/components/detail/AlternativePlacesSidebar.tsx
@@ -1,0 +1,113 @@
+import { useNavigate } from 'react-router-dom';
+import { CaretRightIcon } from '@phosphor-icons/react';
+import { useAlternativeLocations } from '../../hooks/useAlternativeLocations';
+import { LOCATION_MAP } from '../../data/locations';
+import { CATEGORY_NAMES } from '../../data/categories';
+import { CONGESTION_COLORS, CONGESTION_LABELS, CONGESTION_LEVEL_MAP } from '../../types/congestion';
+import type { AlternativeLocation } from '../../types/map';
+import SectionHeader from './SectionHeader';
+
+interface Props {
+  areaCode: string;
+}
+
+const Header = () => (
+  <div className="px-5 py-5 border-b border-slate-100">
+    <SectionHeader title="Alternative Places" size="text-base" />
+    <p className="text-xs text-slate-500 mt-0.5">Similar vibe, less crowded</p>
+  </div>
+);
+
+const Item = ({
+  loc,
+  onClick,
+}: {
+  loc: AlternativeLocation;
+  onClick: () => void;
+}) => {
+  const categoryKey = LOCATION_MAP.get(loc.areaCode)?.category;
+  const categoryName = categoryKey ? CATEGORY_NAMES[categoryKey] : null;
+  const level = CONGESTION_LEVEL_MAP[loc.congestionLevel];
+  const badgeColor = level ? CONGESTION_COLORS[level] : '#9ca3af';
+  const badgeLabel = level ? CONGESTION_LABELS[level] : loc.congestionLevel;
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="cursor-pointer group w-full text-left p-5 hover:bg-blue-50/40 transition-colors block"
+    >
+      <p className="text-base font-bold text-slate-900 tracking-tight truncate">
+        {loc.locationName}
+      </p>
+      <div className="flex items-center gap-2 mt-2.5">
+        {categoryName && (
+          <span className="text-xs text-slate-500 bg-slate-100 rounded-md px-2 py-0.5">
+            {categoryName}
+          </span>
+        )}
+        <div className="flex items-center gap-1.5 shrink-0 ml-auto">
+          <span
+            className="text-xs font-semibold px-2.5 py-1 rounded-full text-white"
+            style={{ backgroundColor: badgeColor }}
+          >
+            {badgeLabel}
+          </span>
+          <CaretRightIcon
+            weight="fill"
+            size={13}
+            className="text-slate-300 group-hover:text-slate-500 group-hover:translate-x-0.5 transition-all"
+          />
+        </div>
+      </div>
+    </button>
+  );
+};
+
+const AlternativePlacesSidebar = ({ areaCode }: Props) => {
+  const navigate = useNavigate();
+  const state = useAlternativeLocations(areaCode);
+
+  return (
+    <aside className="lg:w-72 shrink-0">
+      <div className="bg-white rounded-2xl shadow-sm overflow-hidden">
+        <Header />
+        {state.status === 'loading' && (
+          <div className="divide-y divide-slate-100">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="p-5 animate-pulse">
+                <div className="h-4 bg-slate-200 rounded w-3/4 mb-2.5" />
+                <div className="h-3 bg-slate-100 rounded w-1/3" />
+              </div>
+            ))}
+          </div>
+        )}
+        {state.status === 'error' && (
+          <div className="px-5 py-6 text-center text-slate-400 text-sm">
+            대체 장소를 불러올 수 없어요.
+          </div>
+        )}
+        {state.status === 'empty' && (
+          <div className="px-5 py-6 text-center text-slate-400 text-sm">
+            추천할 대체 장소가 없어요.
+          </div>
+        )}
+        {state.status === 'success' && (
+          <div className="divide-y divide-slate-100">
+            {[...state.data]
+              .sort((a, b) => a.priority - b.priority)
+              .map((loc) => (
+                <Item
+                  key={loc.areaCode}
+                  loc={loc}
+                  onClick={() => navigate(`/place/${loc.areaCode}`)}
+                />
+              ))}
+          </div>
+        )}
+      </div>
+    </aside>
+  );
+};
+
+export default AlternativePlacesSidebar;

--- a/src/components/detail/CongestionHeroCard.tsx
+++ b/src/components/detail/CongestionHeroCard.tsx
@@ -1,0 +1,79 @@
+import { CATEGORY_NAMES } from '../../data/categories';
+import { CONGESTION_LABELS } from '../../types/congestion';
+import type { CongestionLevel } from '../../types/congestion';
+import { getLocationImageUrl } from '../../data/locations';
+import type { Location } from '../../data/locations';
+
+interface Props {
+  placeInfo: Location;
+  congestionLevel: CongestionLevel;
+  color: string;
+  avgPeople: number;
+  populationTime: string;
+  congestionMessage: string;
+}
+
+const CongestionHeroCard = ({
+  placeInfo,
+  congestionLevel,
+  color,
+  avgPeople,
+  populationTime,
+  congestionMessage,
+}: Props) => (
+  <div className="bg-white rounded-2xl overflow-hidden shadow-sm border border-slate-100">
+    <div className="relative bg-slate-100">
+      <img
+        src={getLocationImageUrl(placeInfo.name)}
+        alt={placeInfo.name}
+        className="w-full h-56 object-cover"
+        onError={(e) => {
+          e.currentTarget.style.visibility = 'hidden';
+        }}
+      />
+    </div>
+    <div className="p-8 sm:p-10">
+      <div className="flex items-start justify-between gap-6">
+        <div className="min-w-0 flex-1">
+          <p className="text-[11px] font-medium tracking-[0.08em] text-slate-500 mb-3">
+            #{CATEGORY_NAMES[placeInfo.category]}
+          </p>
+          <h1 className="text-3xl sm:text-4xl font-extrabold text-slate-900 tracking-[-0.025em] leading-[1.05]">
+            {placeInfo.name}
+          </h1>
+        </div>
+        <div className="shrink-0 text-right">
+          <p className="text-2xl font-extrabold tracking-[-0.02em]" style={{ color }}>
+            {CONGESTION_LABELS[congestionLevel]}
+          </p>
+          <p className="mt-1 text-[10px] font-semibold tracking-[0.22em] text-slate-400 uppercase">
+            Status
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-8">
+        <p className="text-[10px] font-semibold tracking-[0.18em] text-slate-400 uppercase mb-1.5">
+          Current Visitors
+        </p>
+        <div className="flex items-baseline gap-1.5">
+          <p className="text-5xl font-extrabold text-slate-900 tracking-[-0.04em] tabular-nums">
+            {avgPeople.toLocaleString()}
+          </p>
+          <p className="text-lg font-light text-slate-400">명</p>
+        </div>
+        <p className="mt-2 text-xs text-slate-400 tabular-nums tracking-wide">
+          {populationTime} 측정
+        </p>
+      </div>
+
+      {congestionMessage && (
+        <p className="mt-8 text-[15px] sm:text-base text-slate-700 leading-[1.75] max-w-prose">
+          {congestionMessage}
+        </p>
+      )}
+    </div>
+  </div>
+);
+
+export default CongestionHeroCard;

--- a/src/components/detail/CultureEventsSection.tsx
+++ b/src/components/detail/CultureEventsSection.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+import { useCultureEvents } from '../../hooks/useCultureEvents';
+import CultureEventCard from '../culture/CultureEventCard';
+import SectionHeader from './SectionHeader';
+
+const EVENTS_PREVIEW = 6;
+
+interface Props {
+  latitude: number;
+  longitude: number;
+}
+
+const CultureEventsSection = ({ latitude, longitude }: Props) => {
+  const state = useCultureEvents(latitude, longitude);
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div>
+      <SectionHeader title="주변 행사/문화 정보" className="mb-4" />
+      {state.status === 'loading' && (
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="bg-white rounded-2xl shadow-sm animate-pulse h-56" />
+          ))}
+        </div>
+      )}
+      {state.status === 'error' && (
+        <div className="bg-white rounded-2xl p-6 shadow-sm text-center text-slate-400 text-sm">
+          행사 정보를 불러올 수 없어요.
+        </div>
+      )}
+      {state.status === 'success' && state.data.length === 0 && (
+        <div className="bg-white rounded-2xl p-6 shadow-sm text-center text-slate-400 text-sm">
+          주변 행사/문화 정보가 없어요.
+        </div>
+      )}
+      {state.status === 'success' && state.data.length > 0 && (
+        <>
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+            {(expanded ? state.data : state.data.slice(0, EVENTS_PREVIEW)).map((event) => (
+              <CultureEventCard key={event.orgLink} event={event} />
+            ))}
+          </div>
+          {!expanded && state.data.length > EVENTS_PREVIEW && (
+            <button
+              type="button"
+              onClick={() => setExpanded(true)}
+              className="cursor-pointer mt-6 mx-auto block text-sm font-medium text-slate-600 hover:text-blue-600 transition-colors"
+            >
+              +{state.data.length - EVENTS_PREVIEW}개 더 보기
+            </button>
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default CultureEventsSection;

--- a/src/components/detail/LocationSection.tsx
+++ b/src/components/detail/LocationSection.tsx
@@ -1,0 +1,51 @@
+import { Map, CustomOverlayMap } from 'react-kakao-maps-sdk';
+import { MapPinIcon } from '@phosphor-icons/react';
+import { useAddress } from '../../hooks/useAddress';
+import MarkerPin from '../map/MarkerPin';
+import SectionHeader from './SectionHeader';
+
+interface Props {
+  latitude: number;
+  longitude: number;
+  color: string;
+}
+
+const LocationSection = ({ latitude, longitude, color }: Props) => {
+  const addressState = useAddress(latitude, longitude);
+  const addressText =
+    addressState.status === 'success'
+      ? addressState.address
+      : addressState.status === 'loading'
+        ? '위치 정보를 불러오는 중...'
+        : '위치 정보를 가져올 수 없어요';
+
+  return (
+    <div>
+      <div className="mb-4">
+        <SectionHeader title="위치" />
+        <p className="mt-2 text-sm text-slate-500 flex items-center gap-1.5">
+          <MapPinIcon weight="fill" size={13} className="text-slate-400 shrink-0" />
+          <span className="truncate">{addressText}</span>
+        </p>
+      </div>
+      <div className="rounded-2xl overflow-hidden shadow-sm border border-slate-100">
+        <Map
+          center={{ lat: latitude, lng: longitude }}
+          style={{ width: '100%', height: '260px' }}
+          level={4}
+        >
+          <CustomOverlayMap position={{ lat: latitude, lng: longitude }} yAnchor={1}>
+            <div
+              className="flex flex-col items-center"
+              style={{ filter: 'drop-shadow(0 3px 8px rgba(0,0,0,0.4))' }}
+            >
+              <MarkerPin color={color} size={36} />
+            </div>
+          </CustomOverlayMap>
+        </Map>
+      </div>
+    </div>
+  );
+};
+
+export default LocationSection;

--- a/src/components/detail/SectionHeader.tsx
+++ b/src/components/detail/SectionHeader.tsx
@@ -1,0 +1,20 @@
+interface Props {
+  title: string;
+  /** Tailwind 텍스트 사이즈 클래스. 메인 섹션은 `text-lg`, 사이드바 등 보조 영역은 `text-base` */
+  size?: 'text-lg' | 'text-base';
+  /** 외부 spacing 등을 위한 추가 클래스 */
+  className?: string;
+}
+
+/**
+ * DetailPage 섹션 헤딩의 공통 마크업.
+ * 좌측 brand-blue 세로 막대(2x20) + h2 타이틀로 일관된 시각 정체성을 갖는다.
+ */
+const SectionHeader = ({ title, size = 'text-lg', className = '' }: Props) => (
+  <div className={`flex items-center gap-2.5 ${className}`}>
+    <span className="w-[2px] h-5 bg-blue-600 shrink-0" />
+    <h2 className={`${size} font-bold text-slate-900 tracking-tight`}>{title}</h2>
+  </div>
+);
+
+export default SectionHeader;

--- a/src/components/filter/CategoryFilter.tsx
+++ b/src/components/filter/CategoryFilter.tsx
@@ -1,12 +1,4 @@
-import { Sparkles, Coffee, ShoppingBag, Trees, Landmark } from 'lucide-react';
-
-const CATEGORIES = [
-  { id: 'all', label: 'All', Icon: Sparkles },
-  { id: 'cafe', label: 'Cafe', Icon: Coffee },
-  { id: 'shopping', label: 'Shopping', Icon: ShoppingBag },
-  { id: 'park', label: 'Park', Icon: Trees },
-  { id: 'culture', label: 'Culture', Icon: Landmark },
-];
+import { CATEGORY_FILTERS } from '../../data/categories';
 
 interface CategoryFilterProps {
   selected: string;
@@ -16,21 +8,21 @@ interface CategoryFilterProps {
 const CategoryFilter = ({ selected, onSelect }: CategoryFilterProps) => {
   return (
     <div className="absolute top-4 inset-x-4 z-10 flex justify-center">
-      <div className="flex items-center gap-2 bg-white rounded-full px-3 py-2 shadow-md overflow-x-auto max-w-full w-fit">
-      {CATEGORIES.map(({ id, label, Icon }) => (
-        <button
-          key={id}
-          onClick={() => onSelect(id)}
-          className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-colors ${
-            selected === id
-              ? 'bg-blue-600 text-white'
-              : 'text-gray-600 hover:bg-gray-100 cursor-pointer'
-          }`}
-        >
-          <Icon size={15} />
-          <span>{label}</span>
-        </button>
-      ))}
+      <div className="flex items-center gap-1 bg-white rounded-full px-2 py-1.5 shadow-md overflow-x-auto max-w-full w-fit">
+        {CATEGORY_FILTERS.map(({ id, label, Icon }) => (
+          <button
+            key={id}
+            onClick={() => onSelect(id)}
+            className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium tracking-tight transition-colors ${
+              selected === id
+                ? 'bg-blue-600 text-white'
+                : 'text-slate-600 hover:bg-slate-100 cursor-pointer'
+            }`}
+          >
+            <Icon size={15} weight="fill" />
+            <span>{label}</span>
+          </button>
+        ))}
       </div>
     </div>
   );

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -45,10 +45,8 @@ const Header = ({ onSearchSelect }: HeaderProps) => {
 
         {/* 우측 영역 */}
         <div className="flex items-center gap-2 sm:gap-4">
-          {/* 검색 (홈, 데스크탑) */}
-          {location.pathname === '/' && onSearchSelect && (
-            <HomeSearch onSelect={onSearchSelect} />
-          )}
+          {/* 검색 (데스크탑) — onSearchSelect 받는 페이지에서만 노출 */}
+          {onSearchSelect && <HomeSearch onSelect={onSearchSelect} />}
 
           {/* 아이콘 (데스크탑) */}
           <button className="hidden sm:flex p-2 hover:bg-gray-100 rounded-lg transition-colors">

--- a/src/components/map/AlternativeLocationBanner.tsx
+++ b/src/components/map/AlternativeLocationBanner.tsx
@@ -1,4 +1,4 @@
-import { Sparkles, X } from 'lucide-react';
+import { SparkleIcon, XIcon } from '@phosphor-icons/react';
 
 interface Props {
   sourceName: string;
@@ -8,19 +8,20 @@ interface Props {
 
 const AlternativeLocationBanner = ({ sourceName, count, onClose }: Props) => {
   return (
-    <div className="absolute top-20 left-1/2 -translate-x-1/2 z-9999 flex items-center gap-3 bg-white rounded-full px-3 py-2 shadow-md whitespace-nowrap">
-      <div className="flex items-center gap-2 pl-2 text-sm text-gray-700">
-        <Sparkles size={14} className="text-blue-500 shrink-0" />
+    <div className="absolute top-20 left-1/2 -translate-x-1/2 z-9999 flex items-center gap-3 bg-white/95 backdrop-blur-sm rounded-full pl-5 pr-2 py-2 shadow-[0_10px_30px_rgba(15,23,42,0.1)] border border-slate-200/60 whitespace-nowrap">
+      <div className="flex items-center gap-2 text-sm text-slate-700 font-medium tracking-tight">
+        <SparkleIcon weight="fill" size={14} className="text-blue-600 shrink-0" />
         <span>
-          {sourceName}의 대체지역 <span className="text-blue-500 font-bold">{count}곳</span>
+          {sourceName}의 대체지역
+          <span className="ml-1.5 text-blue-600 font-extrabold tabular-nums">{count}</span>
+          <span className="text-slate-500">곳</span>
         </span>
       </div>
-      <div className="w-px h-5 bg-gray-200 shrink-0" />
       <button
         onClick={onClose}
-        className="cursor-pointer flex items-center gap-1.5 px-4 py-1.5 bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium rounded-full transition-colors"
+        className="cursor-pointer flex items-center gap-1 px-4 py-1.5 bg-blue-600 hover:bg-blue-700 text-white text-sm font-semibold rounded-full transition-colors"
       >
-        <X size={13} />
+        <XIcon weight="bold" size={12} />
         끄기
       </button>
     </div>

--- a/src/components/map/CongestionMarker.tsx
+++ b/src/components/map/CongestionMarker.tsx
@@ -1,9 +1,9 @@
-import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { CustomOverlayMap } from 'react-kakao-maps-sdk';
 import { X } from 'lucide-react';
 import { CONGESTION_COLORS, CONGESTION_LABELS } from '../../types/congestion';
 import { CATEGORY_NAMES } from '../../data/categories';
+import { useOneShotPulse } from '../../hooks/useOneShotPulse';
 import MarkerPin from './MarkerPin';
 import { calcMarkerSize } from './markerUtils';
 import type { PlaceMarker } from '../../types/congestion';
@@ -33,9 +33,8 @@ const CongestionMarker = ({
   const size = calcMarkerSize(level);
   const avgPeople = Math.round((marker.minPeopleCount + marker.maxPeopleCount) / 2);
 
-  // 검색 선택 시 한 번만 튀도록: 애니메이션을 끝낸 nonce를 기록해 그 외 리렌더(줌 등)에서는 재생 안 함
-  const [finishedNonce, setFinishedNonce] = useState<number | null>(null);
-  const shouldBounce = bounceNonce != null && bounceNonce !== finishedNonce;
+  // 검색 선택 시 한 번만 튀도록: 줌 등 리렌더에서는 재생 안 함
+  const { active: shouldBounce, onAnimationEnd: handleBounceEnd } = useOneShotPulse(bounceNonce);
 
   return (
     <>
@@ -47,7 +46,7 @@ const CongestionMarker = ({
             }`}
             style={{ filter: 'drop-shadow(0 3px 8px rgba(0,0,0,0.3))' }}
             onClick={onOpen}
-            onAnimationEnd={() => setFinishedNonce(bounceNonce ?? null)}
+            onAnimationEnd={handleBounceEnd}
           >
             <MarkerPin color={color} size={size} />
           </div>
@@ -96,12 +95,14 @@ const CongestionMarker = ({
               </div>
 
               <div className="flex flex-col gap-1.5">
-                <button
-                  onClick={() => onAlternativeRequest(marker)}
-                  className="cursor-pointer w-full py-2 rounded-xl bg-blue-50 hover:bg-blue-100 text-blue-600 text-xs font-semibold transition-colors"
-                >
-                  대체지역 추천
-                </button>
+                {marker.congestionLevel !== 'QUIET' && (
+                  <button
+                    onClick={() => onAlternativeRequest(marker)}
+                    className="cursor-pointer w-full py-2 rounded-xl bg-blue-50 hover:bg-blue-100 text-blue-600 text-xs font-semibold transition-colors"
+                  >
+                    대체지역 추천
+                  </button>
+                )}
                 <button
                   onClick={() => navigate(`/place/${marker.areaCode}`, { state: { marker } })}
                   className="cursor-pointer w-full py-2 rounded-xl bg-blue-500 hover:bg-blue-600 text-white text-xs font-semibold transition-colors"

--- a/src/data/categories.ts
+++ b/src/data/categories.ts
@@ -1,3 +1,11 @@
+import {
+  SparkleIcon,
+  CoffeeIcon,
+  ShoppingBagIcon,
+  TreeIcon,
+  BankIcon,
+} from '@phosphor-icons/react';
+import type { Icon } from '@phosphor-icons/react';
 import type { LocationCategory } from './locations';
 
 export const CATEGORY_NAMES: Record<LocationCategory, string> = {
@@ -6,3 +14,20 @@ export const CATEGORY_NAMES: Record<LocationCategory, string> = {
   park: '공원',
   culture: '문화',
 };
+
+// 카테고리 필터: 'all' + 4개 분류. CategoryFilter(HomePage), HotspotsPage에서 공유
+export type FilterCategory = LocationCategory | 'all';
+
+export interface CategoryFilterItem {
+  id: FilterCategory;
+  label: string; // 영문 라벨 (UI 표시)
+  Icon: Icon;
+}
+
+export const CATEGORY_FILTERS: ReadonlyArray<CategoryFilterItem> = [
+  { id: 'all', label: 'All', Icon: SparkleIcon },
+  { id: 'cafe', label: 'Cafe', Icon: CoffeeIcon },
+  { id: 'shopping', label: 'Shopping', Icon: ShoppingBagIcon },
+  { id: 'park', label: 'Park', Icon: TreeIcon },
+  { id: 'culture', label: 'Culture', Icon: BankIcon },
+];

--- a/src/hooks/useAddress.ts
+++ b/src/hooks/useAddress.ts
@@ -1,0 +1,69 @@
+import { useEffect, useState } from 'react';
+
+type State =
+  | { status: 'loading' }
+  | { status: 'success'; address: string }
+  | { status: 'error' };
+
+const SDK_WAIT_INTERVAL_MS = 100;
+const SDK_WAIT_MAX_TRIES = 30; // 100ms × 30 = 3초
+
+/**
+ * window.kakao SDK가 로드될 때까지 대기 후 kakao.maps.load 콜백으로 라이브러리 준비를 보장한다.
+ * services 라이브러리는 index.html의 SDK URL에 &libraries=services가 포함돼 있어야 함.
+ */
+const waitForKakao = (cb: () => void) => {
+  let tries = 0;
+  const tick = () => {
+    if (typeof window.kakao?.maps?.load === 'function') {
+      window.kakao.maps.load(cb);
+      return;
+    }
+    if (tries >= SDK_WAIT_MAX_TRIES) return;
+    tries += 1;
+    window.setTimeout(tick, SDK_WAIT_INTERVAL_MS);
+  };
+  tick();
+};
+
+/**
+ * lat/lng → "서울 성동구 성수동" 형태의 행정구역 주소를 조회한다.
+ * 로딩/성공/실패 상태를 명시적으로 노출해 UI에서 silent 실패를 표시할 수 있다.
+ */
+export const useAddress = (latitude: number | null, longitude: number | null): State => {
+  const [state, setState] = useState<State>({ status: 'loading' });
+
+  useEffect(() => {
+    if (latitude == null || longitude == null) return;
+    let cancelled = false;
+
+    // setState는 모두 비동기 콜백 안 (kakao.maps.load / Kakao 지오코더) — effect body 동기 호출 없음
+    waitForKakao(() => {
+      if (cancelled) return;
+      const services = window.kakao?.maps?.services;
+      if (!services) {
+        setState({ status: 'error' });
+        return;
+      }
+
+      new services.Geocoder().coord2Address(longitude, latitude, (result, status) => {
+        if (cancelled) return;
+        if (status === services.Status.OK && result.length > 0 && result[0].address) {
+          const a = result[0].address;
+          setState({
+            status: 'success',
+            address: `${a.region_1depth_name} ${a.region_2depth_name} ${a.region_3depth_name}`,
+          });
+        } else {
+          setState({ status: 'error' });
+        }
+      });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [latitude, longitude]);
+
+  return state;
+};

--- a/src/hooks/useAddress.ts
+++ b/src/hooks/useAddress.ts
@@ -11,15 +11,19 @@ const SDK_WAIT_MAX_TRIES = 30; // 100ms × 30 = 3초
 /**
  * window.kakao SDK가 로드될 때까지 대기 후 kakao.maps.load 콜백으로 라이브러리 준비를 보장한다.
  * services 라이브러리는 index.html의 SDK URL에 &libraries=services가 포함돼 있어야 함.
+ * 최대 시도 횟수 초과 시 onError를 호출해 무한 로딩 상태를 방지한다.
  */
-const waitForKakao = (cb: () => void) => {
+const waitForKakao = (cb: () => void, onError: () => void) => {
   let tries = 0;
   const tick = () => {
     if (typeof window.kakao?.maps?.load === 'function') {
       window.kakao.maps.load(cb);
       return;
     }
-    if (tries >= SDK_WAIT_MAX_TRIES) return;
+    if (tries >= SDK_WAIT_MAX_TRIES) {
+      onError();
+      return;
+    }
     tries += 1;
     window.setTimeout(tick, SDK_WAIT_INTERVAL_MS);
   };
@@ -34,31 +38,42 @@ export const useAddress = (latitude: number | null, longitude: number | null): S
   const [state, setState] = useState<State>({ status: 'loading' });
 
   useEffect(() => {
-    if (latitude == null || longitude == null) return;
     let cancelled = false;
+    // 좌표가 없으면 즉시 error로 종결해 무한 loading 상태 방지
+    if (latitude == null || longitude == null) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setState({ status: 'error' });
+      return;
+    }
 
     // setState는 모두 비동기 콜백 안 (kakao.maps.load / Kakao 지오코더) — effect body 동기 호출 없음
-    waitForKakao(() => {
-      if (cancelled) return;
-      const services = window.kakao?.maps?.services;
-      if (!services) {
-        setState({ status: 'error' });
-        return;
-      }
-
-      new services.Geocoder().coord2Address(longitude, latitude, (result, status) => {
+    waitForKakao(
+      () => {
         if (cancelled) return;
-        if (status === services.Status.OK && result.length > 0 && result[0].address) {
-          const a = result[0].address;
-          setState({
-            status: 'success',
-            address: `${a.region_1depth_name} ${a.region_2depth_name} ${a.region_3depth_name}`,
-          });
-        } else {
+        const services = window.kakao?.maps?.services;
+        if (!services) {
           setState({ status: 'error' });
+          return;
         }
-      });
-    });
+
+        new services.Geocoder().coord2Address(longitude, latitude, (result, status) => {
+          if (cancelled) return;
+          if (status === services.Status.OK && result.length > 0 && result[0].address) {
+            const a = result[0].address;
+            setState({
+              status: 'success',
+              address: `${a.region_1depth_name} ${a.region_2depth_name} ${a.region_3depth_name}`,
+            });
+          } else {
+            setState({ status: 'error' });
+          }
+        });
+      },
+      // SDK 로드 max 도달 시 — 더 이상 기다리지 않고 error로 노출
+      () => {
+        if (!cancelled) setState({ status: 'error' });
+      },
+    );
 
     return () => {
       cancelled = true;

--- a/src/hooks/useAiReport.ts
+++ b/src/hooks/useAiReport.ts
@@ -25,11 +25,31 @@ const circularHourDiff = (a: number, b: number): number => {
   return d > 12 ? 24 - d : d;
 };
 
+// 서비스가 서울 데이터를 다루므로 사용자 로컬 시간이 아닌 KST 기준 시각이 필요하다.
+// 해외/다른 시간대 브라우저에서도 비교가 정확하도록 Intl로 강제.
+const getSeoulHour = (): number => {
+  try {
+    const formatter = new Intl.DateTimeFormat('en-US', {
+      timeZone: 'Asia/Seoul',
+      hour: 'numeric',
+      hour12: false,
+    });
+    return Number(formatter.format(new Date()));
+  } catch {
+    return new Date().getHours();
+  }
+};
+
 export const useAiReport = (areaCode: string | null) => {
   const [state, setState] = useState<State>({ status: 'loading' });
 
   useEffect(() => {
     if (!areaCode) return;
+
+    // 다른 장소로 이동했을 때 이전 분석이 잠깐 노출되는 stale 표시 방지
+    // (콜백 안 setState만 룰 적용 대상이라, 동기 reset 한 줄은 명시적으로 허용)
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setState({ status: 'loading' });
 
     const controller = new AbortController();
 
@@ -41,7 +61,7 @@ export const useAiReport = (areaCode: string | null) => {
           setState({ status: 'success', data });
           return;
         }
-        const diff = circularHourDiff(reportHour, new Date().getHours());
+        const diff = circularHourDiff(reportHour, getSeoulHour());
         setState(diff > HOUR_TOLERANCE ? { status: 'stale' } : { status: 'success', data });
       })
       .catch((err) => {

--- a/src/hooks/useAiReport.ts
+++ b/src/hooks/useAiReport.ts
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import { fetchAiReport } from '../api/congestionApi';
+import type { AireportResponse } from '../types/congestion';
+
+type State =
+  | { status: 'loading' }
+  | { status: 'success'; data: AireportResponse }
+  | { status: 'empty' } // 404: 해당 장소의 AI 리포트 자체가 아직 생성되지 않음
+  | { status: 'stale' } // 분석은 있지만 현재 시간대와 매칭되지 않음
+  | { status: 'error' };
+
+// 분석이 현재 시간대와 어긋나면 보여주지 않기 위한 허용 폭 (±N시간)
+const HOUR_TOLERANCE = 3;
+
+// "2026-05-24 12:30" → 12
+const parseHour = (populationTime: string): number | null => {
+  const m = populationTime.match(/^\d{4}-\d{2}-\d{2} (\d{2}):/);
+  return m ? Number(m[1]) : null;
+};
+
+// 24시 순환 거리 (예: 23시 vs 1시 → 2)
+const circularHourDiff = (a: number, b: number): number => {
+  const d = Math.abs(a - b);
+  return d > 12 ? 24 - d : d;
+};
+
+export const useAiReport = (areaCode: string | null) => {
+  const [state, setState] = useState<State>({ status: 'loading' });
+
+  useEffect(() => {
+    if (!areaCode) return;
+
+    const controller = new AbortController();
+
+    fetchAiReport(areaCode, controller.signal)
+      .then((data) => {
+        if (controller.signal.aborted) return;
+        const reportHour = parseHour(data.populationTime);
+        if (reportHour == null) {
+          setState({ status: 'success', data });
+          return;
+        }
+        const diff = circularHourDiff(reportHour, new Date().getHours());
+        setState(diff > HOUR_TOLERANCE ? { status: 'stale' } : { status: 'success', data });
+      })
+      .catch((err) => {
+        if (axios.isCancel(err)) return;
+        setState(
+          axios.isAxiosError(err) && err.response?.status === 404
+            ? { status: 'empty' }
+            : { status: 'error' },
+        );
+      });
+
+    return () => controller.abort();
+  }, [areaCode]);
+
+  return state;
+};

--- a/src/hooks/useAlternativeLocations.ts
+++ b/src/hooks/useAlternativeLocations.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import { fetchAlternativeLocations } from '../api/mapApi';
+import type { AlternativeLocation } from '../types/map';
+
+type State =
+  | { status: 'loading' }
+  | { status: 'success'; data: AlternativeLocation[] } // 보장: data.length > 0
+  | { status: 'empty' } // 추천 결과 없음 (빈 배열)
+  | { status: 'error' };
+
+export const useAlternativeLocations = (areaCode: string | null) => {
+  const [state, setState] = useState<State>({ status: 'loading' });
+
+  useEffect(() => {
+    if (!areaCode) return;
+
+    const controller = new AbortController();
+
+    fetchAlternativeLocations(areaCode, controller.signal)
+      .then((data) => {
+        if (controller.signal.aborted) return;
+        setState(data.length === 0 ? { status: 'empty' } : { status: 'success', data });
+      })
+      .catch((err) => {
+        if (!axios.isCancel(err)) setState({ status: 'error' });
+      });
+
+    return () => controller.abort();
+  }, [areaCode]);
+
+  return state;
+};

--- a/src/hooks/useAlternativeLocations.ts
+++ b/src/hooks/useAlternativeLocations.ts
@@ -15,6 +15,10 @@ export const useAlternativeLocations = (areaCode: string | null) => {
   useEffect(() => {
     if (!areaCode) return;
 
+    // 다른 장소로 이동했을 때 이전 대체장소 목록이 잠깐 노출되는 stale 표시 방지
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setState({ status: 'loading' });
+
     const controller = new AbortController();
 
     fetchAlternativeLocations(areaCode, controller.signal)

--- a/src/hooks/useHotspotsFilter.ts
+++ b/src/hooks/useHotspotsFilter.ts
@@ -1,8 +1,10 @@
 import { useSearchParams } from 'react-router-dom';
 import { searchLocationsByName } from '../data/locations';
 import type { LocationCategory } from '../data/locations';
+import type { FilterCategory } from '../data/categories';
 
-export type FilterCategory = LocationCategory | 'all';
+// 단일 진실은 data/categories.ts. 외부 임포트 경로 호환을 위해 re-export
+export type { FilterCategory } from '../data/categories';
 
 const PAGE_SIZE = 12;
 

--- a/src/hooks/useOneShotPulse.ts
+++ b/src/hooks/useOneShotPulse.ts
@@ -1,0 +1,21 @@
+import { useCallback, useState } from 'react';
+
+/**
+ * 외부에서 전달된 nonce가 바뀔 때마다 한 번씩만 펄스 애니메이션이 재생되도록
+ * "활성 여부"와 "애니메이션 종료 핸들러"를 반환한다.
+ *
+ * 사용 예:
+ *   const { active, onAnimationEnd } = useOneShotPulse(focusNonce);
+ *   <div className={active ? 'some-pulse-class' : ''} onAnimationEnd={onAnimationEnd} />
+ *
+ * 줌·드래그 등으로 부모가 리렌더되거나 DOM이 reattach되어도 이미 완료된 nonce는
+ * 다시 재생되지 않는다. 새 nonce가 들어오면 다시 1회 재생한다.
+ */
+export const useOneShotPulse = (nonce: number | null | undefined) => {
+  const [finishedNonce, setFinishedNonce] = useState<number | null>(null);
+  const active = nonce != null && nonce !== finishedNonce;
+  const onAnimationEnd = useCallback(() => {
+    setFinishedNonce(nonce ?? null);
+  }, [nonce]);
+  return { active, onAnimationEnd };
+};

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,4 @@
+@import 'pretendard/dist/web/variable/pretendardvariable.css';
 @import "tailwindcss";
 
 @layer base {
@@ -8,7 +9,18 @@
   }
 
   body {
-    font-family: system-ui, -apple-system, sans-serif;
+    font-family:
+      'Pretendard Variable',
+      Pretendard,
+      -apple-system,
+      BlinkMacSystemFont,
+      system-ui,
+      'Apple SD Gothic Neo',
+      'Noto Sans KR',
+      'Segoe UI',
+      Roboto,
+      sans-serif;
+    font-feature-settings: 'ss06';
   }
 }
 
@@ -59,9 +71,24 @@
   animation: marker-bounce 0.9s ease-out;
 }
 
+/* 랭킹 검색 강조: 선택된 순위 행에 잠시 푸른 배경 플래시 (divided 리스트에서 자연스럽게 보이도록 bg 방식) */
+@keyframes ranking-highlight {
+  0% {
+    background-color: rgb(37 99 235 / 0.12);
+  }
+  100% {
+    background-color: transparent;
+  }
+}
+
+.ranking-highlight {
+  animation: ranking-highlight 1.6s ease-out;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .rank-card-hint,
-  .marker-bounce {
+  .marker-bounce,
+  .ranking-highlight {
     animation: none;
   }
 }

--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -1,13 +1,15 @@
 import { useEffect, useState } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
-import { ArrowLeft, Users, Clock } from 'lucide-react';
+import { CaretLeftIcon } from '@phosphor-icons/react';
 import Header from '../components/layout/Header';
-import CultureEventCard from '../components/culture/CultureEventCard';
+import CongestionHeroCard from '../components/detail/CongestionHeroCard';
+import AiInsightCard from '../components/detail/AiInsightCard';
+import CultureEventsSection from '../components/detail/CultureEventsSection';
+import LocationSection from '../components/detail/LocationSection';
+import AlternativePlacesSidebar from '../components/detail/AlternativePlacesSidebar';
 import { fetchCongestionByAreaCode } from '../api/congestionApi';
-import { useCultureEvents } from '../hooks/useCultureEvents';
-import { LOCATION_MAP, getLocationImageUrl } from '../data/locations';
-import { CATEGORY_NAMES } from '../data/categories';
-import { CONGESTION_COLORS, CONGESTION_LABELS, CONGESTION_LEVEL_MAP } from '../types/congestion';
+import { LOCATION_MAP } from '../data/locations';
+import { CONGESTION_COLORS, CONGESTION_LEVEL_MAP } from '../types/congestion';
 import type { CongestionData, PlaceMarker } from '../types/congestion';
 
 const DetailPage = () => {
@@ -20,8 +22,6 @@ const DetailPage = () => {
 
   const placeInfo = placeId ? LOCATION_MAP.get(placeId) : null;
   const hasMarkerState = !!locationState?.marker;
-
-  const eventsState = useCultureEvents(placeInfo?.latitude ?? null, placeInfo?.longitude ?? null);
 
   useEffect(() => {
     if (!placeId || hasMarkerState) return;
@@ -46,112 +46,68 @@ const DetailPage = () => {
   const populationTime = marker?.populationTime ?? data?.populationTime ?? '';
   const congestionMessage = marker?.congestionMessage ?? data?.congestionMessage ?? '';
 
+  const isUnavailable = !loading && ((!marker && !data) || !placeInfo);
+  const isReady = !loading && (marker || data) && placeInfo && congestionLevel;
+
   return (
-    <div className="flex flex-col w-full min-h-dvh bg-gray-50">
-      <Header />
-      <div className="max-w-5xl mx-auto w-full px-6 py-6">
+    <div className="flex flex-col w-full min-h-dvh bg-slate-50">
+      <Header onSearchSelect={(areaCode) => navigate(`/place/${areaCode}`)} />
+      <div className="max-w-6xl mx-auto w-full px-6 py-6">
         <button
           onClick={() => navigate('/')}
-          className="cursor-pointer flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-800 mb-6 transition-colors"
+          className="cursor-pointer group flex items-center gap-1.5 text-sm text-slate-500 hover:text-slate-900 mb-6 transition-colors"
         >
-          <ArrowLeft size={16} />
+          <CaretLeftIcon
+            weight="fill"
+            size={16}
+            className="group-hover:-translate-x-0.5 transition-transform"
+          />
           Back to Map
         </button>
 
-        {loading && <div className="bg-white rounded-2xl p-6 shadow-sm animate-pulse h-44" />}
+        <div className="flex flex-col lg:flex-row gap-6">
+          <div className="flex-1 min-w-0 space-y-6">
+            {loading && <div className="bg-white rounded-2xl p-6 shadow-sm animate-pulse h-44" />}
 
-        {!loading && ((!marker && !data) || !placeInfo) && (
-          <div className="bg-white rounded-2xl p-6 shadow-sm text-center text-gray-400">
-            장소 정보를 불러올 수 없어요.
-          </div>
-        )}
+            {isUnavailable && (
+              <div className="bg-white rounded-2xl p-6 shadow-sm text-center text-slate-400">
+                장소 정보를 불러올 수 없어요.
+              </div>
+            )}
 
-        {!loading && (marker || data) && placeInfo && congestionLevel && (
-          <div className="bg-white rounded-2xl overflow-hidden shadow-sm">
-            <div className="relative bg-gray-100">
-              <img
-                src={getLocationImageUrl(placeInfo.name)}
-                alt={placeInfo.name}
-                className="w-full h-56 object-cover"
-                onError={(e) => {
-                  e.currentTarget.style.visibility = 'hidden';
-                }}
+            {isReady && placeInfo && congestionLevel && (
+              <CongestionHeroCard
+                placeInfo={placeInfo}
+                congestionLevel={congestionLevel}
+                color={color}
+                avgPeople={avgPeople}
+                populationTime={populationTime}
+                congestionMessage={congestionMessage}
               />
-            </div>
-            <div className="p-6">
-              <div className="flex items-start justify-between">
-                <div>
-                  <h1 className="text-2xl font-bold text-gray-900">{placeInfo.name}</h1>
-                  <div className="flex gap-1.5 mt-2">
-                    <span className="text-xs text-gray-500 bg-gray-100 rounded-full px-2.5 py-1">
-                      {`#${CATEGORY_NAMES[placeInfo.category]}`}
-                    </span>
-                  </div>
-                </div>
-                <span
-                  className="text-sm font-bold px-3 py-1.5 rounded-full text-white mt-1 shrink-0"
-                  style={{ backgroundColor: color }}
-                >
-                  {CONGESTION_LABELS[congestionLevel]}
-                </span>
-              </div>
+            )}
 
-              {congestionMessage && (
-                <p className="mt-4 text-sm text-gray-600 leading-relaxed">{congestionMessage}</p>
-              )}
+            {placeInfo && placeId && <AiInsightCard areaCode={placeId} />}
 
-              <div className="flex gap-8 mt-6">
-                <div className="flex items-center gap-3">
-                  <div className="w-10 h-10 bg-blue-50 rounded-xl flex items-center justify-center">
-                    <Users size={18} className="text-blue-500" />
-                  </div>
-                  <div>
-                    <p className="text-xs text-gray-400">Current Visitors</p>
-                    <p className="text-xl font-bold text-gray-900">{avgPeople.toLocaleString()}</p>
-                  </div>
-                </div>
-                <div className="flex items-center gap-3">
-                  <div className="w-10 h-10 bg-purple-50 rounded-xl flex items-center justify-center">
-                    <Clock size={18} className="text-purple-500" />
-                  </div>
-                  <div>
-                    <p className="text-xs text-gray-400">Updated</p>
-                    <p className="text-sm font-medium text-gray-900">{populationTime}</p>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        )}
-        {placeInfo && (
-          <div className="mt-6">
-            <h2 className="text-base font-bold text-gray-800 mb-3">주변 행사/문화 정보</h2>
-            {eventsState.status === 'loading' && (
-              <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
-                {Array.from({ length: 3 }).map((_, i) => (
-                  <div key={i} className="bg-white rounded-2xl shadow-sm animate-pulse h-56" />
-                ))}
-              </div>
+            {placeInfo && (
+              <CultureEventsSection
+                latitude={placeInfo.latitude}
+                longitude={placeInfo.longitude}
+              />
             )}
-            {eventsState.status === 'error' && (
-              <div className="bg-white rounded-2xl p-6 shadow-sm text-center text-gray-400 text-sm">
-                행사 정보를 불러올 수 없어요.
-              </div>
-            )}
-            {eventsState.status === 'success' && eventsState.data.length === 0 && (
-              <div className="bg-white rounded-2xl p-6 shadow-sm text-center text-gray-400 text-sm">
-                주변 행사/문화 정보가 없어요.
-              </div>
-            )}
-            {eventsState.status === 'success' && eventsState.data.length > 0 && (
-              <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
-                {eventsState.data.map((event) => (
-                  <CultureEventCard key={event.orgLink} event={event} />
-                ))}
-              </div>
+
+            {placeInfo && (
+              <LocationSection
+                latitude={placeInfo.latitude}
+                longitude={placeInfo.longitude}
+                color={color}
+              />
             )}
           </div>
-        )}
+
+          {placeInfo && placeId && congestionLevel !== 'QUIET' && (
+            <AlternativePlacesSidebar areaCode={placeId} />
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/pages/HotspotsPage.tsx
+++ b/src/pages/HotspotsPage.tsx
@@ -1,29 +1,10 @@
 import { useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import {
-  TrendingUp,
-  Search,
-  Sparkles,
-  Coffee,
-  ShoppingBag,
-  Trees,
-  Landmark,
-  ChevronLeft,
-  ChevronRight,
-} from 'lucide-react';
+import { TrendingUp, Search, ChevronLeft, ChevronRight } from 'lucide-react';
 import Header from '../components/layout/Header';
 import { getLocationImageUrl } from '../data/locations';
-import { CATEGORY_NAMES } from '../data/categories';
+import { CATEGORY_NAMES, CATEGORY_FILTERS } from '../data/categories';
 import { useHotspotsFilter } from '../hooks/useHotspotsFilter';
-import type { FilterCategory } from '../hooks/useHotspotsFilter';
-
-const CATEGORY_FILTERS: { value: FilterCategory; label: string; icon: React.ElementType }[] = [
-  { value: 'all', label: 'All', icon: Sparkles },
-  { value: 'cafe', label: 'Cafe', icon: Coffee },
-  { value: 'shopping', label: 'Shopping', icon: ShoppingBag },
-  { value: 'park', label: 'Park', icon: Trees },
-  { value: 'culture', label: 'Culture', icon: Landmark },
-];
 
 const HotspotsPage = () => {
   const navigate = useNavigate();
@@ -93,18 +74,18 @@ const HotspotsPage = () => {
         </div>
 
         <div className="flex gap-2 mb-8 flex-wrap">
-          {CATEGORY_FILTERS.map(({ value, label, icon: Icon }) => (
+          {CATEGORY_FILTERS.map(({ id, label, Icon }) => (
             <button
-              key={value}
+              key={id}
               type="button"
-              onClick={() => handleCategory(value)}
-              className={`cursor-pointer flex items-center gap-1.5 px-4 py-2 rounded-full text-sm font-medium transition-colors ${
-                activeCategory === value
+              onClick={() => handleCategory(id)}
+              className={`cursor-pointer flex items-center gap-1.5 px-4 py-2 rounded-full text-sm font-medium tracking-tight transition-colors ${
+                activeCategory === id
                   ? 'bg-blue-600 text-white'
-                  : 'bg-white text-gray-600 hover:bg-gray-100 border border-gray-200'
+                  : 'bg-white text-slate-600 hover:bg-slate-100 border border-slate-200'
               }`}
             >
-              <Icon size={14} />
+              <Icon size={14} weight="fill" />
               {label}
             </button>
           ))}

--- a/src/pages/RankingPage.tsx
+++ b/src/pages/RankingPage.tsx
@@ -1,59 +1,77 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { TrendingUp, TrendingDown, ArrowLeft, Users } from 'lucide-react';
+import { CaretLeftIcon } from '@phosphor-icons/react';
 import Header from '../components/layout/Header';
 import { useRanking } from '../hooks/useRanking';
+import { useOneShotPulse } from '../hooks/useOneShotPulse';
 import { LOCATION_MAP } from '../data/locations';
 import { CATEGORY_NAMES } from '../data/categories';
 import { CONGESTION_LEVEL_MAP, CONGESTION_COLORS, CONGESTION_LABELS } from '../types/congestion';
 import type { RankingEntry } from '../types/congestion';
-
-const RANK_BADGE: Record<number, string> = {
-  1: 'bg-yellow-400 text-white',
-  2: 'bg-gray-400 text-white',
-  3: 'bg-amber-600 text-white',
-};
+import { extractPopulationHourMinute } from '../utils/date';
 
 interface RankingItemProps {
   entry: RankingEntry;
   onClick: () => void;
+  focusNonce?: number | null;
 }
 
-const RankingItem = ({ entry, onClick }: RankingItemProps) => {
+const RankingItem = ({ entry, onClick, focusNonce }: RankingItemProps) => {
   const level = CONGESTION_LEVEL_MAP[entry.congestionLevel];
   const color = level ? CONGESTION_COLORS[level] : '#9ca3af';
   const label = level ? CONGESTION_LABELS[level] : entry.congestionLevel;
   const location = LOCATION_MAP.get(entry.areaCode);
-  const category = location ? `#${CATEGORY_NAMES[location.category]}` : null;
+  const categoryName = location ? CATEGORY_NAMES[location.category] : null;
   const avgPeople = Math.round((entry.minPeopleCount + entry.maxPeopleCount) / 2);
+
+  const itemRef = useRef<HTMLButtonElement>(null);
+  const { active: shouldHighlight, onAnimationEnd: handleHighlightEnd } =
+    useOneShotPulse(focusNonce);
+
+  useEffect(() => {
+    if (focusNonce != null) {
+      itemRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }, [focusNonce]);
 
   return (
     <button
+      ref={itemRef}
       type="button"
       onClick={onClick}
-      className="w-full text-left cursor-pointer bg-white rounded-2xl px-8 py-5 flex items-center gap-6 hover:shadow-md transition-shadow"
+      onAnimationEnd={handleHighlightEnd}
+      className={`w-full text-left cursor-pointer px-7 py-5 flex items-baseline gap-6 hover:bg-slate-50/70 transition-colors ${
+        shouldHighlight ? 'ranking-highlight' : ''
+      }`}
     >
-      <div
-        className={`w-14 h-14 rounded-full flex items-center justify-center text-lg font-bold shrink-0 ${
-          RANK_BADGE[entry.rank] ?? 'bg-gray-100 text-gray-500'
+      <span
+        className={`text-4xl font-extrabold tabular-nums tracking-tight w-12 shrink-0 leading-none ${
+          entry.rank === 1
+            ? 'text-amber-500'
+            : entry.rank === 2
+              ? 'text-slate-500'
+              : entry.rank === 3
+                ? 'text-amber-700'
+                : 'text-slate-300'
         }`}
       >
-        {entry.rank}
-      </div>
+        {String(entry.rank).padStart(2, '0')}
+      </span>
 
-      <div className="flex-1 min-w-0">
-        <p className="text-lg font-semibold text-gray-900 truncate">{entry.areaName}</p>
-        <div className="flex items-center gap-3 mt-1.5">
-          {category && <span className="text-base text-gray-400">{category}</span>}
-          <span className="flex items-center gap-1 text-base text-gray-400">
-            <Users size={15} />
-            {avgPeople.toLocaleString()}명
-          </span>
-        </div>
+      <div className="flex-1 min-w-0 self-center">
+        <p className="text-lg font-bold text-slate-900 tracking-tight truncate">
+          {entry.areaName}
+        </p>
+        <p className="mt-1 text-sm text-slate-500">
+          {categoryName && <span>{categoryName}</span>}
+          {categoryName && <span className="mx-1.5 text-slate-300">·</span>}
+          <span className="tabular-nums">{avgPeople.toLocaleString()}명</span>
+        </p>
       </div>
 
       <span
-        className="text-base font-semibold px-5 py-2 rounded-full text-white shrink-0"
-        style={{ backgroundColor: color }}
+        className="self-center text-xs font-semibold px-3 py-1.5 rounded-full text-white shrink-0"
+        style={{ backgroundColor: color, boxShadow: `0 4px 14px ${color}40` }}
       >
         {label}
       </span>
@@ -69,73 +87,119 @@ const RankingPage = () => {
 
   const { entries, loading, error } = useRanking(tab);
   const isBusiest = tab === 'busiest';
+  const [searchFocus, setSearchFocus] = useState<{ areaCode: string; nonce: number } | null>(null);
+  const latestTime = entries[0]?.populationTime
+    ? extractPopulationHourMinute(entries[0].populationTime)
+    : undefined;
+
+  // 검색으로 선택된 장소가 현재 랭킹에 있으면 그 카드 강조, 없으면 silent
+  const handleSearchSelect = useCallback((areaCode: string) => {
+    setSearchFocus({ areaCode, nonce: Date.now() });
+  }, []);
+
+  // 탭 전환 시 검색 focus 해제 — 새 탭에 같은 장소가 있어도 재애니메이션 안 되도록
+  const handleTabChange = useCallback(
+    (newTab: 'busiest' | 'relaxed') => {
+      setSearchFocus(null);
+      setSearchParams({ tab: newTab });
+    },
+    [setSearchParams],
+  );
 
   return (
-    <div className="flex flex-col w-full min-h-dvh bg-gray-50">
-      <Header />
-      <div className="max-w-7xl mx-auto w-full px-6 py-8">
+    <div className="flex flex-col w-full min-h-dvh bg-slate-50">
+      <Header onSearchSelect={handleSearchSelect} />
+      <div className="max-w-6xl mx-auto w-full px-6 py-10">
         <button
           onClick={() => navigate('/')}
-          className="cursor-pointer flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-800 mb-8 transition-colors"
+          className="cursor-pointer group flex items-center gap-1.5 text-sm text-slate-500 hover:text-slate-900 mb-8 transition-colors"
         >
-          <ArrowLeft size={16} />
-          메인으로 돌아가기
+          <CaretLeftIcon
+            weight="fill"
+            size={14}
+            className="group-hover:-translate-x-0.5 transition-transform"
+          />
+          Back to Map
         </button>
 
-        <h1 className="text-3xl font-bold text-gray-900">실시간 랭킹</h1>
-        <p className="text-base text-gray-400 mt-1.5">
-          서울 핫플레이스의 실시간 혼잡도를 확인하세요
-        </p>
+        <div className="flex items-end justify-between gap-4">
+          <div className="min-w-0">
+            <h1 className="text-3xl sm:text-4xl font-extrabold text-slate-900 tracking-tight leading-[1.1]">
+              실시간 랭킹
+            </h1>
+            <p className="mt-3 text-sm text-slate-500">
+              서울 핫플레이스의 혼잡도를 한눈에
+            </p>
+          </div>
 
-        <div className="flex gap-8 mt-8 border-b border-gray-200">
+          {latestTime && (
+            <div className="hidden sm:flex items-center gap-2 shrink-0 mb-1.5 text-xs">
+              <span className="relative flex h-2 w-2">
+                <span className="absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75 animate-ping" />
+                <span className="relative inline-flex rounded-full h-2 w-2 bg-green-500" />
+              </span>
+              <span className="font-semibold tracking-[0.18em] text-slate-700 uppercase">
+                Live
+              </span>
+              <span className="text-slate-300">·</span>
+              <span className="tabular-nums text-slate-500">{latestTime} 기준</span>
+            </div>
+          )}
+        </div>
+
+        <div className="mt-8 inline-flex gap-1 p-1 bg-slate-100/80 rounded-full">
           <button
-            onClick={() => setSearchParams({ tab: 'busiest' })}
-            className={`cursor-pointer flex items-center gap-2 pb-3 text-base font-medium border-b-2 transition-colors ${
+            onClick={() => handleTabChange('busiest')}
+            className={`cursor-pointer px-5 py-2 text-sm font-semibold tracking-tight rounded-full transition ${
               isBusiest
-                ? 'border-red-500 text-red-500'
-                : 'border-transparent text-gray-400 hover:text-gray-600'
+                ? 'bg-white text-slate-900 shadow-sm'
+                : 'text-slate-500 hover:text-slate-700'
             }`}
           >
-            <TrendingUp size={17} />
             혼잡도 높은 순
           </button>
           <button
-            onClick={() => setSearchParams({ tab: 'relaxed' })}
-            className={`cursor-pointer flex items-center gap-2 pb-3 text-base font-medium border-b-2 transition-colors ${
+            onClick={() => handleTabChange('relaxed')}
+            className={`cursor-pointer px-5 py-2 text-sm font-semibold tracking-tight rounded-full transition ${
               !isBusiest
-                ? 'border-green-500 text-green-500'
-                : 'border-transparent text-gray-400 hover:text-gray-600'
+                ? 'bg-white text-slate-900 shadow-sm'
+                : 'text-slate-500 hover:text-slate-700'
             }`}
           >
-            <TrendingDown size={17} />
             혼잡도 낮은 순
           </button>
         </div>
 
-        <div className="mt-5 space-y-3">
+        <div className="mt-6 bg-white rounded-2xl border border-slate-100 overflow-hidden">
           {loading && (
-            <>
+            <div className="divide-y divide-slate-100">
               {Array.from({ length: 5 }).map((_, i) => (
-                <div key={i} className="h-24 bg-white rounded-2xl animate-pulse" />
+                <div key={i} className="h-20 animate-pulse" />
               ))}
-            </>
+            </div>
           )}
 
           {!loading && error && (
-            <div className="bg-white rounded-2xl p-8 text-center text-gray-400">
+            <div className="p-8 text-center text-sm text-slate-400">
               데이터를 불러올 수 없습니다
             </div>
           )}
 
-          {!loading &&
-            !error &&
-            entries.map((entry) => (
-              <RankingItem
-                key={entry.areaCode}
-                entry={entry}
-                onClick={() => navigate(`/place/${entry.areaCode}`)}
-              />
-            ))}
+          {!loading && !error && (
+            <ul className="divide-y divide-slate-100">
+              {entries.map((entry) => (
+                <li key={entry.areaCode}>
+                  <RankingItem
+                    entry={entry}
+                    focusNonce={
+                      searchFocus?.areaCode === entry.areaCode ? searchFocus.nonce : null
+                    }
+                    onClick={() => navigate(`/place/${entry.areaCode}`)}
+                  />
+                </li>
+              ))}
+            </ul>
+          )}
         </div>
       </div>
     </div>

--- a/src/types/congestion.ts
+++ b/src/types/congestion.ts
@@ -18,8 +18,8 @@ export const CONGESTION_LABELS: Record<CongestionLevel, string> = {
 
 export const CONGESTION_COLORS: Record<CongestionLevel, string> = {
   QUIET: '#22c55e', // green-500
-  MODERATE: '#fb923c', // orange-400
-  BUSY: '#facc15', // yellow-400
+  MODERATE: '#facc15', // yellow-400
+  BUSY: '#fb923c', // orange-400
   CROWDED: '#ef4444', // red-500
 };
 
@@ -69,5 +69,13 @@ export interface PlaceMarker {
   congestionMessage: string;
   minPeopleCount: number;
   maxPeopleCount: number;
+  populationTime: string;
+}
+
+// AI 혼잡 원인 분석 리포트
+export interface AireportResponse {
+  areaCode: string;
+  areaName: string;
+  analysisMessage: string;
   populationTime: string;
 }

--- a/src/types/kakao.d.ts
+++ b/src/types/kakao.d.ts
@@ -1,0 +1,31 @@
+// kakao.maps.services 라이브러리 타입 보강
+// SDK URL에 &libraries=services를 추가해야 사용 가능 (index.html 참조)
+
+declare namespace kakao.maps {
+  // SDK 부트스트랩 콜백. 라이브러리(services 등)까지 모두 준비되면 호출됨.
+  function load(callback: () => void): void;
+
+  namespace services {
+    interface Address {
+      region_1depth_name: string;
+      region_2depth_name: string;
+      region_3depth_name: string;
+    }
+
+    interface Coord2AddressResult {
+      address?: Address;
+    }
+
+    type Coord2AddressCallback = (result: Coord2AddressResult[], status: string) => void;
+
+    class Geocoder {
+      coord2Address(lng: number, lat: number, callback: Coord2AddressCallback): void;
+    }
+
+    const Status: {
+      readonly OK: string;
+      readonly ZERO_RESULT: string;
+      readonly ERROR: string;
+    };
+  }
+}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,12 @@
+// 서울 실시간 도시데이터 API의 populationTime 포맷("YYYY-MM-DD HH:MM")을
+// "YYYY년 M월 D일 HH시 MM분" 형태로 변환한다. 파싱 실패 시 원본 반환.
+export const formatPopulationTime = (populationTime: string): string => {
+  const match = populationTime.match(/^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2})/);
+  if (!match) return populationTime;
+  const [, year, month, day, hour, minute] = match;
+  return `${year}년 ${Number(month)}월 ${Number(day)}일 ${hour}시 ${minute}분`;
+};
+
+// "YYYY-MM-DD HH:MM" → "HH:MM"
+export const extractPopulationHourMinute = (populationTime: string): string =>
+  populationTime.slice(11, 16);


### PR DESCRIPTION
## 관련 이슈
#21
> AI Insight 카드와 대체장소 사이드바를 구현했습니다.
## 변경 사항

### 상세페이지
- AI 혼잡 원인 분석 카드 추가 (`GET /api/congestion/{areaCode}/ai-report`)
  - 분석의 측정 시각이 현재 시간과 ±3시간 이내일 때만 노출, 그 외엔 "이 시간대 AI 분석은 아직 준비되지 않았어요" 안내
  - 로딩, 분석 있음, 시간대 미매칭, 데이터 없음, 에러 상태 분기
- 위치 미니맵 추가 (`react-kakao-maps-sdk`) 와 kakao Geocoder 로 좌표→주소 자동 표시
- 대체장소 추천 사이드바 추가 (`GET /api/map/alternative-location`), 클릭 시 해당 장소 상세로 이동
- QUIET(여유) 장소에선 사이드바 자동 숨김 → 본문 전체 폭으로 확장
- 주변 행사/문화 정보 6개 초과 시 "더 보기" 토글
- DetailPage 를 sub-components 5개로 분리 (`CongestionHeroCard`, `AiInsightCard`, `CultureEventsSection`, `LocationSection`, `AlternativePlacesSidebar`)

### 랭킹페이지
- 헤더 검색하면 현재 랭킹의 해당 카드로 스크롤 + 강조 애니메이션 1회 재생, 탭 전환 시 자동 해제
- LIVE 인디케이터와 최신 측정 시각 표시
- 1·2·3위 순위 숫자에 차등 색 적용 (amber-500 / slate-500 / amber-700)
- 탭을 pill 토글 스타일로 변경

### 헤더 검색
- 홈 전용 → `onSearchSelect` prop 받는 모든 페이지에서 노출
- DetailPage 에서 검색: 다른 장소 상세로 이동
- RankingPage 에서 검색: 해당 랭킹 카드 강조

### 디자인 시스템
- Pretendard Variable 폰트 도입
- 페이지 아이콘을 Phosphor Icons (fill weight) 로 통일 (lucide → phosphor)
- 카테고리 정의를 `data/categories.ts` 로 단일화하여 Home `CategoryFilter` 와 `HotspotsPage` 가 공유
- 혼잡도 MODERATE/BUSY 색 매핑 정정 (yellow ↔ orange)
- 대체지역 추천 배너 디자인 다듬기
- 마커 팝업에서 QUIET 장소는 "대체지역 추천" 버튼 숨김

### 새 훅·유틸
- `useAiReport`: AI 리포트 조회 + 시간대 매칭 + 상태 분기
- `useAddress`: 좌표→주소 변환 (`kakao.maps.load` 콜백 사용)
- `useAlternativeLocations`: 대체장소 추천 데이터
- `useOneShotPulse`: 일회성 펄스 애니메이션 (CongestionMarker / RankingItem 공유)
- `formatPopulationTime`, `extractPopulationHourMinute`: 시각 포맷 유틸

### 리팩터링
- DetailPage 를 sub-components 로 분리, 페이지는 상태 + 조립만 담당
- 펄스 애니메이션의 `finishedNonce` 패턴 중복을 `useOneShotPulse` 훅으로 추출
- 섹션 헤더 마크업 4곳 중복을 `<SectionHeader>` 공통 컴포넌트로 분리
- 카테고리 정의 2곳 중복 (`CategoryFilter`, `HotspotsPage`) 을 `data/categories.ts` 로 통합
- `kakao.maps.services` 타입 보강 (`src/types/kakao.d.ts`) 으로 더블 타입 캐스트 제거
