### PR TITLE
feat: Route Planner 페이지 구현 (대중교통 경로 검색)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import HomePage from './pages/HomePage';
 import DetailPage from './pages/DetailPage';
 import RankingPage from './pages/RankingPage';
 import HotspotsPage from './pages/HotspotsPage';
+import RoutePlannerPage from './pages/RoutePlannerPage';
 
 function App() {
   return (
@@ -11,6 +12,7 @@ function App() {
       <Route path="/place/:placeId" element={<DetailPage />} />
       <Route path="/ranking" element={<RankingPage />} />
       <Route path="/hotspots" element={<HotspotsPage />} />
+      <Route path="/route" element={<RoutePlannerPage />} />
     </Routes>
   );
 }

--- a/src/api/routeApi.ts
+++ b/src/api/routeApi.ts
@@ -1,0 +1,25 @@
+import instance from './instance';
+import type { ApiResponse } from '../types/api';
+import type { TransitRouteResponse } from '../types/route';
+
+export interface Coord {
+  lat: number;
+  lng: number;
+}
+
+export const fetchTransitRoute = async (
+  origin: Coord,
+  destination: Coord,
+  signal?: AbortSignal,
+): Promise<TransitRouteResponse> => {
+  const res = await instance.get<ApiResponse<TransitRouteResponse>>('/api/mobility/route', {
+    params: {
+      originLat: origin.lat,
+      originLng: origin.lng,
+      destLat: destination.lat,
+      destLng: destination.lng,
+    },
+    signal,
+  });
+  return res.data.data;
+};

--- a/src/components/route/DestinationPreviewCard.tsx
+++ b/src/components/route/DestinationPreviewCard.tsx
@@ -1,0 +1,84 @@
+import { useState } from 'react';
+import { LOCATION_MAP, getLocationImageUrl } from '../../data/locations';
+import { CATEGORY_NAMES } from '../../data/categories';
+import {
+  CONGESTION_LEVEL_MAP,
+  CONGESTION_COLORS,
+  CONGESTION_LABELS,
+} from '../../types/congestion';
+import { useDestinationCongestion } from '../../hooks/useDestinationCongestion';
+
+interface Props {
+  areaCode: string;
+}
+
+/**
+ * 도착지로 선택된 핫스팟의 현재 혼잡도를 보여주는 헤더 카드.
+ * 일반 길찾기 앱과 다른 본 서비스의 차별점(혼잡도 데이터 연계)을 결과 위에 노출한다.
+ */
+const DestinationPreviewCard = ({ areaCode }: Props) => {
+  const [imageOk, setImageOk] = useState(true);
+  const location = LOCATION_MAP.get(areaCode);
+  const state = useDestinationCongestion(areaCode);
+
+  if (!location) return null;
+
+  const data = state.status === 'success' ? state.data : null;
+  const level = data ? CONGESTION_LEVEL_MAP[data.congestionLevel] : null;
+  const color = level ? CONGESTION_COLORS[level] : null;
+  const label = level ? CONGESTION_LABELS[level] : null;
+  const avgPeople = data
+    ? Math.round((data.minPeopleCount + data.maxPeopleCount) / 2)
+    : null;
+
+  return (
+    <div className="bg-white rounded-2xl ring-1 ring-slate-100 overflow-hidden">
+      <div className="flex items-stretch">
+        {imageOk && (
+          <div className="w-24 sm:w-28 shrink-0 bg-slate-100">
+            <img
+              src={getLocationImageUrl(location.name)}
+              alt={location.name}
+              className="w-full h-full object-cover"
+              onError={() => setImageOk(false)}
+            />
+          </div>
+        )}
+
+        <div className="flex-1 min-w-0 px-5 py-4 flex flex-col justify-center">
+          <p className="text-xs text-slate-400 font-medium">
+            도착지 · {CATEGORY_NAMES[location.category]}
+          </p>
+          <h3 className="mt-0.5 text-lg font-semibold text-slate-900 tracking-tight truncate">
+            {location.name}
+          </h3>
+
+          <div className="mt-2.5 min-h-[24px] flex items-center gap-2.5">
+            {state.status === 'loading' && (
+              <span className="inline-block w-20 h-5 rounded-md bg-slate-100 animate-pulse" />
+            )}
+            {level && color && label && (
+              <span
+                className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-semibold text-white"
+                style={{ backgroundColor: color }}
+              >
+                <span className="size-1.5 rounded-full bg-white/90" />
+                {label}
+              </span>
+            )}
+            {avgPeople !== null && (
+              <span className="text-xs text-slate-500 tabular-nums">
+                현재 {avgPeople.toLocaleString()}명
+              </span>
+            )}
+            {state.status === 'error' && (
+              <span className="text-xs text-slate-400">혼잡도 정보 없음</span>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DestinationPreviewCard;

--- a/src/components/route/DestinationSelect.tsx
+++ b/src/components/route/DestinationSelect.tsx
@@ -1,0 +1,99 @@
+import { useMemo, useState } from 'react';
+import { Navigation, X } from 'lucide-react';
+import { LOCATION_MAP, searchLocationsByName } from '../../data/locations';
+import { CATEGORY_NAMES } from '../../data/categories';
+
+const MAX_RESULTS = 8;
+
+interface Props {
+  value: string | null; // areaCode
+  onChange: (areaCode: string | null) => void;
+}
+
+const DestinationSelect = ({ value, onChange }: Props) => {
+  const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false);
+
+  const results = useMemo(() => {
+    if (!query.trim()) return [];
+    return searchLocationsByName(query).slice(0, MAX_RESULTS);
+  }, [query]);
+
+  const selectedLocation = value ? LOCATION_MAP.get(value) : null;
+
+  const handleSelect = (areaCode: string) => {
+    onChange(areaCode);
+    setQuery('');
+    setOpen(false);
+  };
+
+  const handleClear = () => {
+    onChange(null);
+    setQuery('');
+  };
+
+  return (
+    <div className="relative">
+      <div className="flex items-center gap-2.5 px-3.5 py-2.5 bg-slate-50 rounded-lg ring-1 ring-transparent focus-within:bg-white focus-within:ring-slate-900/10 transition-all">
+        <Navigation className="size-4 text-slate-400 shrink-0" strokeWidth={1.75} />
+        {selectedLocation ? (
+          <span className="flex-1 text-sm text-slate-900 truncate">{selectedLocation.name}</span>
+        ) : (
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setOpen(true);
+            }}
+            onFocus={() => setOpen(true)}
+            onBlur={() => setOpen(false)}
+            placeholder="핫플레이스 검색"
+            aria-label="도착지 선택"
+            className="flex-1 bg-transparent text-sm outline-none placeholder:text-slate-400"
+          />
+        )}
+        {selectedLocation && (
+          <button
+            type="button"
+            onClick={handleClear}
+            aria-label="도착지 지우기"
+            className="cursor-pointer p-0.5 hover:bg-slate-200/60 rounded transition-colors"
+          >
+            <X className="size-4 text-slate-400" strokeWidth={1.75} />
+          </button>
+        )}
+      </div>
+
+      {open && !selectedLocation && query.trim() && (
+        <div
+          onMouseDown={(e) => e.preventDefault()}
+          className="absolute top-full left-0 right-0 mt-1.5 bg-white rounded-lg shadow-lg ring-1 ring-slate-900/5 overflow-hidden z-10"
+        >
+          {results.length > 0 ? (
+            <ul className="py-1 max-h-72 overflow-y-auto">
+              {results.map((loc) => (
+                <li key={loc.areaCode}>
+                  <button
+                    type="button"
+                    onClick={() => handleSelect(loc.areaCode)}
+                    className="cursor-pointer w-full text-left px-3.5 py-2.5 hover:bg-slate-50 transition-colors flex items-center justify-between gap-3"
+                  >
+                    <span className="text-sm font-medium text-slate-900 truncate">{loc.name}</span>
+                    <span className="text-xs text-slate-400 shrink-0">
+                      {CATEGORY_NAMES[loc.category]}
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className="px-3.5 py-3 text-sm text-slate-400">검색 결과가 없어요</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DestinationSelect;

--- a/src/components/route/OriginSearchInput.tsx
+++ b/src/components/route/OriginSearchInput.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useRef, useState } from 'react';
+import { MapPin, X } from 'lucide-react';
+import { waitForKakao } from '../../utils/kakaoSdk';
+
+const SEARCH_DEBOUNCE_MS = 250;
+const MAX_RESULTS = 6;
+
+export interface OriginSelection {
+  label: string;
+  lat: number;
+  lng: number;
+}
+
+interface Props {
+  value: OriginSelection | null;
+  onChange: (next: OriginSelection | null) => void;
+}
+
+const OriginSearchInput = ({ value, onChange }: Props) => {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<kakao.maps.services.PlacesSearchResultItem[]>([]);
+  const [open, setOpen] = useState(false);
+  const placesRef = useRef<kakao.maps.services.Places | null>(null);
+
+  // SDK 준비되면 Places 인스턴스를 한 번만 생성해 재사용
+  useEffect(() => {
+    waitForKakao(() => {
+      const Places = window.kakao?.maps?.services?.Places;
+      if (Places) placesRef.current = new Places();
+    });
+  }, []);
+
+  // 디바운스: 입력이 멈춘 뒤에만 검색 호출. 빈 쿼리는 effect 자체를 skip하고
+  // 표시 시점에 derive(query 비면 빈 배열 표시)하여 동기 setState를 피한다.
+  // active flag로 언마운트/dep 변경 후 kakao 콜백이 stale setState 호출하는 것 차단.
+  useEffect(() => {
+    if (!query.trim() || value) return;
+    let active = true;
+    const timer = window.setTimeout(() => {
+      if (!active) return;
+      const places = placesRef.current;
+      if (!places) return;
+      places.keywordSearch(query, (data, status) => {
+        if (!active) return;
+        const ok = window.kakao?.maps?.services?.Status?.OK;
+        setResults(status === ok ? data.slice(0, MAX_RESULTS) : []);
+      });
+    }, SEARCH_DEBOUNCE_MS);
+    return () => {
+      active = false;
+      window.clearTimeout(timer);
+    };
+  }, [query, value]);
+
+  const visibleResults = query.trim() && !value ? results : [];
+
+  const handleSelect = (item: kakao.maps.services.PlacesSearchResultItem) => {
+    onChange({
+      label: item.place_name,
+      lat: Number(item.y),
+      lng: Number(item.x),
+    });
+    setQuery('');
+    setResults([]);
+    setOpen(false);
+  };
+
+  const handleClear = () => {
+    onChange(null);
+    setQuery('');
+    setResults([]);
+  };
+
+  return (
+    <div className="relative">
+      <div className="flex items-center gap-2.5 px-3.5 py-2.5 bg-slate-50 rounded-lg ring-1 ring-transparent focus-within:bg-white focus-within:ring-slate-900/10 transition-all">
+        <MapPin className="size-4 text-slate-400 shrink-0" strokeWidth={1.75} />
+        {value ? (
+          <span className="flex-1 text-sm text-slate-900 truncate">{value.label}</span>
+        ) : (
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setOpen(true);
+            }}
+            onFocus={() => setOpen(true)}
+            onBlur={() => setOpen(false)}
+            placeholder="장소 또는 주소"
+            aria-label="출발지 검색"
+            className="flex-1 bg-transparent text-sm outline-none placeholder:text-slate-400"
+          />
+        )}
+        {value && (
+          <button
+            type="button"
+            onClick={handleClear}
+            aria-label="출발지 지우기"
+            className="cursor-pointer p-0.5 hover:bg-slate-200/60 rounded transition-colors"
+          >
+            <X className="size-4 text-slate-400" strokeWidth={1.75} />
+          </button>
+        )}
+      </div>
+
+      {open && !value && query.trim() && (
+        <div
+          onMouseDown={(e) => e.preventDefault()}
+          className="absolute top-full left-0 right-0 mt-1.5 bg-white rounded-lg shadow-lg ring-1 ring-slate-900/5 overflow-hidden z-10"
+        >
+          {visibleResults.length > 0 ? (
+            <ul className="py-1 max-h-72 overflow-y-auto">
+              {visibleResults.map((item) => (
+                <li key={item.id}>
+                  <button
+                    type="button"
+                    onClick={() => handleSelect(item)}
+                    className="cursor-pointer w-full text-left px-3.5 py-2.5 hover:bg-slate-50 transition-colors"
+                  >
+                    <p className="text-sm font-medium text-slate-900 truncate">
+                      {item.place_name}
+                    </p>
+                    <p className="text-xs text-slate-500 truncate mt-0.5">
+                      {item.road_address_name || item.address_name}
+                    </p>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className="px-3.5 py-3 text-sm text-slate-400">검색 결과가 없어요</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default OriginSearchInput;

--- a/src/components/route/OriginSearchInput.tsx
+++ b/src/components/route/OriginSearchInput.tsx
@@ -20,13 +20,19 @@ const OriginSearchInput = ({ value, onChange }: Props) => {
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<kakao.maps.services.PlacesSearchResultItem[]>([]);
   const [open, setOpen] = useState(false);
+  const [sdkReady, setSdkReady] = useState(false);
   const placesRef = useRef<kakao.maps.services.Places | null>(null);
 
-  // SDK 준비되면 Places 인스턴스를 한 번만 생성해 재사용
+  // SDK 준비되면 Places 인스턴스를 한 번만 생성해 재사용.
+  // sdkReady state를 함께 올려, SDK 로드보다 사용자 입력이 빨라도 첫 검색이 silent fail하지 않도록
+  // 아래 search effect가 sdkReady 변경 시 재실행되어 pending query를 처리한다.
   useEffect(() => {
     waitForKakao(() => {
       const Places = window.kakao?.maps?.services?.Places;
-      if (Places) placesRef.current = new Places();
+      if (Places) {
+        placesRef.current = new Places();
+        setSdkReady(true);
+      }
     });
   }, []);
 
@@ -34,7 +40,7 @@ const OriginSearchInput = ({ value, onChange }: Props) => {
   // 표시 시점에 derive(query 비면 빈 배열 표시)하여 동기 setState를 피한다.
   // active flag로 언마운트/dep 변경 후 kakao 콜백이 stale setState 호출하는 것 차단.
   useEffect(() => {
-    if (!query.trim() || value) return;
+    if (!query.trim() || value || !sdkReady) return;
     let active = true;
     const timer = window.setTimeout(() => {
       if (!active) return;
@@ -50,7 +56,7 @@ const OriginSearchInput = ({ value, onChange }: Props) => {
       active = false;
       window.clearTimeout(timer);
     };
-  }, [query, value]);
+  }, [query, value, sdkReady]);
 
   const visibleResults = query.trim() && !value ? results : [];
 

--- a/src/components/route/RouteIllustration.tsx
+++ b/src/components/route/RouteIllustration.tsx
@@ -1,0 +1,32 @@
+/**
+ * 출발지 → 도착지를 잇는 작은 곡선 일러스트. 빈 상태(empty/idle)에서 시각적 무게를 더해
+ * 페이지가 비어 보이지 않게 한다. 출발=하늘색 핀, 도착=어두운 핀으로 색상 위계 분리.
+ */
+interface Props {
+  className?: string;
+}
+
+const RouteIllustration = ({ className }: Props) => (
+  <svg viewBox="0 0 160 56" fill="none" className={className} aria-hidden="true">
+    {/* Origin pin (sky) */}
+    <circle cx="18" cy="36" r="14" fill="#38BDF8" opacity="0.12" />
+    <circle cx="18" cy="36" r="7" fill="#0EA5E9" />
+    <circle cx="18" cy="36" r="3" fill="white" />
+
+    {/* Dotted curve */}
+    <path
+      d="M 28 36 Q 80 -4 132 36"
+      stroke="#CBD5E1"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeDasharray="2 5"
+    />
+
+    {/* Destination pin (slate) */}
+    <circle cx="142" cy="36" r="14" fill="#0F172A" opacity="0.08" />
+    <circle cx="142" cy="36" r="7" fill="#0F172A" />
+    <circle cx="142" cy="36" r="3" fill="white" />
+  </svg>
+);
+
+export default RouteIllustration;

--- a/src/components/route/RoutePathCard.tsx
+++ b/src/components/route/RoutePathCard.tsx
@@ -1,0 +1,158 @@
+import { ChevronDown } from 'lucide-react';
+import RouteTimeline from './RouteTimeline';
+import { TRAFFIC_STYLE, getLaneLabel, getSubPathColor, withAlpha } from './trafficStyle';
+import { resolveSubwayColor, cleanSubwayName } from '../../data/subwayLineColors';
+import type { RoutePath, RouteSubPath } from '../../types/route';
+
+interface Props {
+  path: RoutePath;
+  expanded: boolean;
+  isFastest: boolean;
+  destinationAreaCode: string;
+  originLabel: string;
+  destinationLabel: string;
+  onToggle: () => void;
+  onDestinationClick: (areaCode: string) => void;
+}
+
+// 구간별 소요시간 비율 바. 지하철 구간은 노선 공식색으로 표시되어
+// "이 경로는 2호선 위주" 같은 직관적 파악이 가능하다.
+const ProportionalBar = ({ subPaths }: { subPaths: RouteSubPath[] }) => (
+  <div className="flex h-1 rounded-full overflow-hidden bg-slate-100 gap-px">
+    {subPaths.map((sp, i) => (
+      <div key={i} style={{ flex: sp.sectionTime, backgroundColor: getSubPathColor(sp) }} />
+    ))}
+  </div>
+);
+
+// 사용 노선 칩. 지하철은 공식 노선색 솔리드 배경 + 화이트 텍스트 (실제 사인 스타일).
+// 버스는 라이트 톤 칩. 동일 구간을 잇는 노선이 여러 개면:
+//   - BUS: " / "로 묶어 한 칩 (같은 파랑 톤이라 자연스러움)
+//   - SUBWAY: lane별 칩 분리 → 각자의 공식 노선색 살림
+const ModeChipRow = ({ subPaths }: { subPaths: RouteSubPath[] }) => {
+  const transits = subPaths.filter((sp) => sp.trafficType !== 'WALK');
+  if (transits.length === 0) return null;
+
+  return (
+    <div className="flex items-center gap-1.5 flex-wrap">
+      {transits.flatMap((sp, i) => {
+        const Icon = TRAFFIC_STYLE[sp.trafficType].Icon;
+
+        if (sp.trafficType === 'SUBWAY') {
+          return sp.lane.map((lane, j) => {
+            const color = resolveSubwayColor(lane.name);
+            return (
+              <span
+                key={`${i}-${j}`}
+                style={{ backgroundColor: color }}
+                className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs font-semibold text-white"
+              >
+                <Icon className="size-3" strokeWidth={2.25} />
+                {cleanSubwayName(lane.name) ?? '지하철'}
+              </span>
+            );
+          });
+        }
+
+        const color = getSubPathColor(sp);
+        const label = getLaneLabel(sp);
+        return [
+          <span
+            key={i}
+            style={{ backgroundColor: withAlpha(color, '1A'), color }}
+            className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs font-semibold"
+          >
+            <Icon className="size-3" strokeWidth={2} />
+            {label}
+          </span>,
+        ];
+      })}
+    </div>
+  );
+};
+
+const RoutePathCard = ({
+  path,
+  expanded,
+  isFastest,
+  destinationAreaCode,
+  originLabel,
+  destinationLabel,
+  onToggle,
+  onDestinationClick,
+}: Props) => {
+  const { info, subPaths } = path;
+  const transferCount = info.busTransitCount + info.subwayTransitCount;
+
+  return (
+    <article
+      className={`relative bg-white rounded-2xl transition-all duration-200 overflow-hidden ${
+        expanded
+          ? 'ring-1 ring-slate-900/10 shadow-[0_8px_30px_-12px_rgb(15,23,42,0.18)]'
+          : isFastest
+            ? 'ring-1 ring-blue-100 hover:ring-blue-200/80'
+            : 'ring-1 ring-slate-100 hover:ring-slate-200'
+      }`}
+    >
+      <button
+        type="button"
+        onClick={onToggle}
+        className="cursor-pointer w-full text-left p-5"
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0 flex-1">
+            {isFastest && (
+              <p className="mb-1.5 text-[11px] font-semibold text-blue-600 tracking-tight">
+                최단 경로
+              </p>
+            )}
+
+            <div className="flex items-baseline gap-1.5">
+              <span className="text-[32px] font-semibold tabular-nums leading-none tracking-tight text-slate-900">
+                {info.totalTime}
+              </span>
+              <span className="text-sm font-medium text-slate-400">분</span>
+            </div>
+
+            <div className="mt-2 flex items-center gap-2.5 text-xs text-slate-500">
+              <span className="tabular-nums">{info.payment.toLocaleString()}원</span>
+              <span className="size-1 rounded-full bg-slate-200" />
+              <span>
+                환승 <span className="tabular-nums text-slate-700">{transferCount}</span>회
+              </span>
+            </div>
+          </div>
+
+          <ChevronDown
+            strokeWidth={1.75}
+            className={`size-5 text-slate-300 shrink-0 mt-1 transition-transform duration-200 ${
+              expanded ? 'rotate-180 text-slate-500' : ''
+            }`}
+          />
+        </div>
+
+        <div className="mt-4">
+          <ProportionalBar subPaths={subPaths} />
+        </div>
+
+        <div className="mt-3">
+          <ModeChipRow subPaths={subPaths} />
+        </div>
+      </button>
+
+      {expanded && (
+        <div className="px-5 pb-5">
+          <div className="h-px bg-slate-100 mb-3" />
+          <RouteTimeline
+            subPaths={subPaths}
+            originLabel={originLabel}
+            destinationLabel={destinationLabel}
+            onDestinationClick={() => onDestinationClick(destinationAreaCode)}
+          />
+        </div>
+      )}
+    </article>
+  );
+};
+
+export default RoutePathCard;

--- a/src/components/route/RouteTimeline.tsx
+++ b/src/components/route/RouteTimeline.tsx
@@ -1,0 +1,263 @@
+import { useMemo } from 'react';
+import type { ReactNode } from 'react';
+import { TRAFFIC_STYLE, getLaneLabel, getSubPathColor } from './trafficStyle';
+import type { RouteSubPath } from '../../types/route';
+
+const WALK_COLOR = '#CBD5E1'; // slate-300 — 가벼움/짧음
+const ENDPOINT_COLOR = '#0F172A'; // slate-900 — 출발/도착 강조
+
+interface StationRow {
+  kind: 'station';
+  name: string;
+  color: string;
+  topColor: string | null;
+  bottomColor: string | null;
+  topDashed: boolean;
+  bottomDashed: boolean;
+  tag?: '출발' | '도착';
+  clickable?: boolean;
+}
+
+interface SegmentRow {
+  kind: 'segment';
+  color: string;
+  dashed: boolean;
+  content: ReactNode;
+}
+
+type Row = StationRow | SegmentRow;
+
+const formatLabel = (subPath: RouteSubPath): string => {
+  const label = getLaneLabel(subPath);
+  if (subPath.trafficType === 'BUS') return `${label}번`;
+  return label;
+};
+
+const buildMeta = (subPath: RouteSubPath): string | null => {
+  const parts: string[] = [];
+  if (subPath.intervalTime != null) parts.push(`${subPath.intervalTime}분 간격`);
+  if (subPath.way) parts.push(`${subPath.way} 방향`);
+  return parts.length > 0 ? parts.join(' · ') : null;
+};
+
+/**
+ * 출발→도착 전체 여정을 (역 dot) + (구간 bar)로 시각화.
+ * 도보=점선 회색 / 대중교통=노선 공식색 솔리드.
+ * 두 인접 transit 사이 walking transfer는 중간 점이 두 번 찍혀 환승 인지가 자연스럽다.
+ */
+const RouteTimeline = ({
+  subPaths,
+  originLabel,
+  destinationLabel,
+  onDestinationClick,
+}: {
+  subPaths: RouteSubPath[];
+  originLabel: string;
+  destinationLabel: string;
+  onDestinationClick: () => void;
+}) => {
+  const rows = useMemo<Row[]>(() => {
+    const list: Row[] = [];
+
+    list.push({
+      kind: 'station',
+      name: originLabel,
+      color: ENDPOINT_COLOR,
+      topColor: null,
+      bottomColor: null,
+      topDashed: false,
+      bottomDashed: false,
+      tag: '출발',
+    });
+
+    for (const sp of subPaths) {
+      if (sp.trafficType === 'WALK') {
+        list.push({
+          kind: 'segment',
+          color: WALK_COLOR,
+          dashed: true,
+          content: (
+            <div className="py-2 flex items-baseline gap-2">
+              <span className="text-[13px] font-medium text-slate-500">도보</span>
+              <span className="text-[11px] text-slate-400 tabular-nums">
+                {sp.sectionTime}분
+              </span>
+            </div>
+          ),
+        });
+        continue;
+      }
+
+      const color = getSubPathColor(sp);
+      const stations = sp.stations ?? [];
+      const board = stations[0];
+      const alight = stations.length > 1 ? stations[stations.length - 1] : null;
+      const Icon = TRAFFIC_STYLE[sp.trafficType].Icon;
+      const label = formatLabel(sp);
+      const meta = buildMeta(sp);
+
+      if (board) {
+        list.push({
+          kind: 'station',
+          name: board,
+          color,
+          topColor: null,
+          bottomColor: null,
+          topDashed: false,
+          bottomDashed: false,
+        });
+      }
+
+      list.push({
+        kind: 'segment',
+        color,
+        dashed: false,
+        content: (
+          <div className="py-2.5 pl-1">
+            <div className="flex items-center gap-1.5 flex-wrap">
+              <Icon className="size-3.5 shrink-0" style={{ color }} strokeWidth={2.25} />
+              <span className="text-[13.5px] font-semibold" style={{ color }}>
+                {label}
+              </span>
+              <span className="text-xs text-slate-400 tabular-nums shrink-0">
+                {sp.sectionTime}분
+              </span>
+            </div>
+            {meta && <p className="mt-1 pl-[20px] text-xs text-slate-400">{meta}</p>}
+          </div>
+        ),
+      });
+
+      if (alight) {
+        list.push({
+          kind: 'station',
+          name: alight,
+          color,
+          topColor: null,
+          bottomColor: null,
+          topDashed: false,
+          bottomDashed: false,
+        });
+      }
+    }
+
+    list.push({
+      kind: 'station',
+      name: destinationLabel,
+      color: ENDPOINT_COLOR,
+      topColor: null,
+      bottomColor: null,
+      topDashed: false,
+      bottomDashed: false,
+      tag: '도착',
+      clickable: true,
+    });
+
+    // 인접 segment 색/스타일로 station의 위·아래 stub bar를 채워 시각 연속성 확보
+    for (let i = 0; i < list.length; i++) {
+      const row = list[i];
+      if (row.kind !== 'station') continue;
+      const above = list[i - 1];
+      const below = list[i + 1];
+      if (above?.kind === 'segment') {
+        row.topColor = above.color;
+        row.topDashed = above.dashed;
+      }
+      if (below?.kind === 'segment') {
+        row.bottomColor = below.color;
+        row.bottomDashed = below.dashed;
+      }
+    }
+
+    return list;
+  }, [subPaths, originLabel, destinationLabel]);
+
+  return (
+    <ol className="grid grid-cols-[20px_1fr] gap-x-4">
+      {rows.map((row, i) => (
+        // display: contents — li 시맨틱은 유지하면서 grid 레이아웃엔 영향 없게
+        <li key={i} className="contents">
+          {row.kind === 'station' ? (
+            <StationRow row={row} onClick={row.clickable ? onDestinationClick : undefined} />
+          ) : (
+            <SegmentRowView color={row.color} dashed={row.dashed}>
+              {row.content}
+            </SegmentRowView>
+          )}
+        </li>
+      ))}
+    </ol>
+  );
+};
+
+const Stub = ({ color, dashed }: { color: string | null; dashed: boolean }) => {
+  if (!color) return <div className="flex-1" />;
+  if (dashed) {
+    return (
+      <div
+        className="flex-1 border-l-[2px] border-dashed"
+        style={{ borderColor: color }}
+      />
+    );
+  }
+  return (
+    <div className="flex-1 w-[3px] rounded-full" style={{ backgroundColor: color }} />
+  );
+};
+
+const StationRow = ({ row, onClick }: { row: StationRow; onClick?: () => void }) => (
+  <>
+    <div className="self-stretch flex flex-col items-center min-h-[30px]">
+      <Stub color={row.topColor} dashed={row.topDashed} />
+      <div
+        className="size-2.5 rounded-full shrink-0 my-0.5 ring-[3px] ring-white"
+        style={{ backgroundColor: row.color }}
+      />
+      <Stub color={row.bottomColor} dashed={row.bottomDashed} />
+    </div>
+    <div className="min-w-0 py-1.5 flex items-baseline gap-2 min-h-[30px]">
+      {onClick ? (
+        <button
+          type="button"
+          onClick={onClick}
+          className="cursor-pointer text-[15px] font-semibold text-slate-900 hover:text-blue-600 hover:underline underline-offset-2 truncate"
+        >
+          {row.name}
+        </button>
+      ) : (
+        <span className="text-[15px] font-semibold text-slate-900 truncate">{row.name}</span>
+      )}
+      {row.tag && (
+        <span className="text-[10px] font-bold uppercase tracking-[0.12em] text-slate-400 shrink-0">
+          {row.tag}
+        </span>
+      )}
+    </div>
+  </>
+);
+
+const SegmentRowView = ({
+  color,
+  dashed,
+  children,
+}: {
+  color: string;
+  dashed: boolean;
+  children: ReactNode;
+}) => (
+  <>
+    <div className="self-stretch flex justify-center">
+      {dashed ? (
+        <div
+          className="border-l-[2px] border-dashed h-full"
+          style={{ borderColor: color }}
+        />
+      ) : (
+        <div className="w-[3px] h-full rounded-full" style={{ backgroundColor: color }} />
+      )}
+    </div>
+    <div className="min-w-0">{children}</div>
+  </>
+);
+
+export default RouteTimeline;

--- a/src/components/route/trafficStyle.ts
+++ b/src/components/route/trafficStyle.ts
@@ -1,0 +1,44 @@
+import { Footprints, Bus, Train } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import type { RouteSubPath, TrafficType } from '../../types/route';
+import { resolveSubwayColor, cleanSubwayName } from '../../data/subwayLineColors';
+
+interface Style {
+  hex: string;
+  Icon: LucideIcon;
+  label: string;
+}
+
+// 도보=중성 회색, 버스=브랜드 청색 (logo blue-600), 지하철=호선별 공식색.
+// hex로 통일해 inline style로 적용 — 호선 색상이 Tailwind 팔레트 밖이라 클래스로 표현 불가.
+export const TRAFFIC_STYLE: Record<TrafficType, Style> = {
+  WALK: { hex: '#64748B', Icon: Footprints, label: '도보' }, // slate-500
+  BUS: { hex: '#2563EB', Icon: Bus, label: '버스' }, // blue-600
+  SUBWAY: { hex: '#8B5CF6', Icon: Train, label: '지하철' }, // violet-500 (호선 매핑 실패 시)
+};
+
+// SUBWAY는 호선별 공식 색상 lookup, 그 외 모드는 type 기본색 반환
+export const getSubPathColor = (subPath: RouteSubPath): string => {
+  if (subPath.trafficType !== 'SUBWAY') return TRAFFIC_STYLE[subPath.trafficType].hex;
+  return resolveSubwayColor(subPath.lane[0]?.name);
+};
+
+// hex + 8자리 alpha — bg-{color}-50 정도의 옅은 톤을 얻기 위한 헬퍼
+export const withAlpha = (hex: string, alphaHex: string): string => `${hex}${alphaHex}`;
+
+/**
+ * 같은 구간을 운행하는 노선이 여러 개일 수 있음 (ODSAY가 `lane` 배열로 내려줌).
+ * 예: 1101 / 1102 / 1103번 버스가 모두 같은 OD 구간 운행 → " / "로 묶어 표시.
+ */
+export const getLaneLabel = (subPath: RouteSubPath): string => {
+  if (subPath.trafficType === 'WALK') return '도보';
+  if (subPath.lane.length === 0) return TRAFFIC_STYLE[subPath.trafficType].label;
+  if (subPath.trafficType === 'BUS') {
+    const busNos = subPath.lane.map((l) => l.busNo).filter((n): n is string => Boolean(n));
+    return busNos.length > 0 ? busNos.join(' / ') : '버스';
+  }
+  const names = subPath.lane
+    .map((l) => cleanSubwayName(l.name))
+    .filter((n): n is string => Boolean(n));
+  return names.length > 0 ? names.join(' / ') : '지하철';
+};

--- a/src/data/subwayLineColors.ts
+++ b/src/data/subwayLineColors.ts
@@ -1,0 +1,54 @@
+// 수도권 도시철도 공식 노선 색상.
+// ODSAY 응답의 subPath.lane[0].name(예: "1호선", "신분당선")을 키로 lookup한다.
+// 운영사 공식 사인/노선도 가이드 기준 hex.
+export const SUBWAY_LINE_COLORS: Record<string, string> = {
+  '1호선': '#0052A4',
+  '2호선': '#009D3E',
+  '3호선': '#EF7C1C',
+  '4호선': '#00A5DE',
+  '5호선': '#996CAC',
+  '6호선': '#CD7C2F',
+  '7호선': '#747F00',
+  '8호선': '#E6186C',
+  '9호선': '#BDB092',
+  공항철도: '#0090D2',
+  경의중앙선: '#77C4A3',
+  경춘선: '#178C72',
+  수인분당선: '#FABE00',
+  신분당선: '#D4003B',
+  우이신설선: '#B7C450',
+  서해선: '#81A914',
+  김포골드라인: '#A17800',
+  신림선: '#6789CA',
+  'GTX-A': '#9A6292',
+  인천1호선: '#6E98BB',
+  인천2호선: '#ED8B00',
+  용인경전철: '#509F22',
+  의정부경전철: '#FDA600',
+};
+
+// 매핑되지 않는 노선의 fallback (violet-500)
+export const DEFAULT_SUBWAY_COLOR = '#8B5CF6';
+
+/**
+ * ODSAY가 "수도권 1호선" 같은 접두어를 붙여 내려주는데, 서비스 자체가 수도권 기반이라
+ * 노출 시 중복임 — 표시 직전 "수도권 " 접두어를 제거한다.
+ * 예: "수도권 7호선" → "7호선", "수도권 수인.분당선" → "수인.분당선"
+ */
+export const cleanSubwayName = (name: string | null | undefined): string | null => {
+  if (!name) return null;
+  return name.replace(/^수도권\s*/, '').trim();
+};
+
+/**
+ * 접두어가 붙어 와도 공백 제거 + 부분 일치까지 fallback해서 색을 결정한다.
+ */
+export const resolveSubwayColor = (name: string | null | undefined): string => {
+  if (!name) return DEFAULT_SUBWAY_COLOR;
+  const cleaned = name.replace(/\s+/g, '');
+  if (SUBWAY_LINE_COLORS[cleaned]) return SUBWAY_LINE_COLORS[cleaned];
+  for (const [key, color] of Object.entries(SUBWAY_LINE_COLORS)) {
+    if (cleaned.includes(key)) return color;
+  }
+  return DEFAULT_SUBWAY_COLOR;
+};

--- a/src/hooks/useAddress.ts
+++ b/src/hooks/useAddress.ts
@@ -1,34 +1,10 @@
 import { useEffect, useState } from 'react';
+import { waitForKakao } from '../utils/kakaoSdk';
 
 type State =
   | { status: 'loading' }
   | { status: 'success'; address: string }
   | { status: 'error' };
-
-const SDK_WAIT_INTERVAL_MS = 100;
-const SDK_WAIT_MAX_TRIES = 30; // 100ms × 30 = 3초
-
-/**
- * window.kakao SDK가 로드될 때까지 대기 후 kakao.maps.load 콜백으로 라이브러리 준비를 보장한다.
- * services 라이브러리는 index.html의 SDK URL에 &libraries=services가 포함돼 있어야 함.
- * 최대 시도 횟수 초과 시 onError를 호출해 무한 로딩 상태를 방지한다.
- */
-const waitForKakao = (cb: () => void, onError: () => void) => {
-  let tries = 0;
-  const tick = () => {
-    if (typeof window.kakao?.maps?.load === 'function') {
-      window.kakao.maps.load(cb);
-      return;
-    }
-    if (tries >= SDK_WAIT_MAX_TRIES) {
-      onError();
-      return;
-    }
-    tries += 1;
-    window.setTimeout(tick, SDK_WAIT_INTERVAL_MS);
-  };
-  tick();
-};
 
 /**
  * lat/lng → "서울 성동구 성수동" 형태의 행정구역 주소를 조회한다.
@@ -47,7 +23,6 @@ export const useAddress = (latitude: number | null, longitude: number | null): S
     }
 
     // 다른 좌표로 이동했을 때 이전 주소가 잠깐 노출되는 stale 표시 방지
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     setState({ status: 'loading' });
     waitForKakao(
       () => {

--- a/src/hooks/useDestinationCongestion.ts
+++ b/src/hooks/useDestinationCongestion.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import { fetchCongestionByAreaCode } from '../api/congestionApi';
+import type { CongestionData } from '../types/congestion';
+
+type State =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'success'; data: CongestionData }
+  | { status: 'error' };
+
+/**
+ * Route Planner의 도착지 미리보기에서 사용. 선택된 핫스팟의 현재 혼잡도를 조회한다.
+ * 서비스 핵심 가치(실시간 혼잡도)를 경로 결과 화면에서 직접 노출해 일반 길찾기 앱과의
+ * 차별점을 만든다.
+ */
+export const useDestinationCongestion = (areaCode: string | null): State => {
+  const [state, setState] = useState<State>({ status: 'idle' });
+
+  useEffect(() => {
+    if (!areaCode) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setState({ status: 'idle' });
+      return;
+    }
+
+    // 다른 도착지로 바꿨을 때 이전 데이터가 잠깐 노출되는 stale 표시 방지
+    setState({ status: 'loading' });
+
+    let cancelled = false;
+    fetchCongestionByAreaCode(areaCode)
+      .then((data) => {
+        if (!cancelled) setState({ status: 'success', data });
+      })
+      .catch(() => {
+        if (!cancelled) setState({ status: 'error' });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [areaCode]);
+
+  return state;
+};

--- a/src/hooks/useTransitRoute.ts
+++ b/src/hooks/useTransitRoute.ts
@@ -1,0 +1,55 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import axios from 'axios';
+import { fetchTransitRoute } from '../api/routeApi';
+import type { Coord } from '../api/routeApi';
+import type { TransitRouteResponse } from '../types/route';
+
+type State =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'success'; data: TransitRouteResponse }
+  | { status: 'empty' }
+  | { status: 'error' };
+
+interface UseTransitRouteReturn {
+  state: State;
+  search: (origin: Coord, destination: Coord) => void;
+  reset: () => void;
+}
+
+/**
+ * 경로 검색을 명시적 트리거(버튼 클릭)로 호출하는 훅.
+ * 자동 fetch 패턴이 아닌 이유: 출발지/도착지 둘 다 선택 안 된 상태로도 페이지가 살아있어야 하고,
+ * 사용자가 의도적으로 검색을 누른 시점에만 API 호출이 발생해야 함.
+ */
+export const useTransitRoute = (): UseTransitRouteReturn => {
+  const [state, setState] = useState<State>({ status: 'idle' });
+  const controllerRef = useRef<AbortController | null>(null);
+
+  const search = useCallback((origin: Coord, destination: Coord) => {
+    controllerRef.current?.abort();
+    const controller = new AbortController();
+    controllerRef.current = controller;
+    setState({ status: 'loading' });
+
+    fetchTransitRoute(origin, destination, controller.signal)
+      .then((data) => {
+        if (controller.signal.aborted) return;
+        setState(data.paths.length === 0 ? { status: 'empty' } : { status: 'success', data });
+      })
+      .catch((err) => {
+        if (axios.isCancel(err)) return;
+        setState({ status: 'error' });
+      });
+  }, []);
+
+  const reset = useCallback(() => {
+    controllerRef.current?.abort();
+    setState({ status: 'idle' });
+  }, []);
+
+  // 언마운트 시 진행 중인 요청 취소
+  useEffect(() => () => controllerRef.current?.abort(), []);
+
+  return { state, search, reset };
+};

--- a/src/pages/RoutePlannerPage.tsx
+++ b/src/pages/RoutePlannerPage.tsx
@@ -1,0 +1,234 @@
+import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { CaretLeftIcon } from '@phosphor-icons/react';
+import { ArrowRight } from 'lucide-react';
+import Header from '../components/layout/Header';
+import OriginSearchInput from '../components/route/OriginSearchInput';
+import type { OriginSelection } from '../components/route/OriginSearchInput';
+import DestinationSelect from '../components/route/DestinationSelect';
+import DestinationPreviewCard from '../components/route/DestinationPreviewCard';
+import RoutePathCard from '../components/route/RoutePathCard';
+import RouteIllustration from '../components/route/RouteIllustration';
+import { useTransitRoute } from '../hooks/useTransitRoute';
+import { LOCATION_MAP } from '../data/locations';
+
+const RoutePlannerPage = () => {
+  const navigate = useNavigate();
+  const [origin, setOrigin] = useState<OriginSelection | null>(null);
+  const [destAreaCode, setDestAreaCode] = useState<string | null>(null);
+  const [expandedIdx, setExpandedIdx] = useState<number>(0);
+  const { state, search, reset } = useTransitRoute();
+
+  // 총 소요시간 오름차순 — 가장 빠른 경로가 최상단/기본 펼침
+  const sortedPaths = useMemo(() => {
+    if (state.status !== 'success') return [];
+    return [...state.data.paths].sort((a, b) => a.info.totalTime - b.info.totalTime);
+  }, [state]);
+
+  const canSearch = origin !== null && destAreaCode !== null;
+
+  const handleSearch = () => {
+    if (!origin || !destAreaCode) return;
+    const dest = LOCATION_MAP.get(destAreaCode);
+    if (!dest) return;
+    setExpandedIdx(0);
+    search(
+      { lat: origin.lat, lng: origin.lng },
+      { lat: dest.latitude, lng: dest.longitude },
+    );
+  };
+
+  const handleOriginChange = (next: OriginSelection | null) => {
+    setOrigin(next);
+    if (state.status !== 'idle') reset();
+  };
+  const handleDestChange = (next: string | null) => {
+    setDestAreaCode(next);
+    if (state.status !== 'idle') reset();
+  };
+
+  // 펼친 카드를 다시 누르면 접힘 — -1을 "모두 접힘" sentinel로 사용
+  const handleToggle = (idx: number) => {
+    setExpandedIdx((prev) => (prev === idx ? -1 : idx));
+  };
+
+  return (
+    <div className="flex flex-col w-full min-h-dvh bg-white">
+      <Header />
+
+      {/* 컨텐츠 영역에 두 개의 매우 옅은 ambient blob — 페이지에 따뜻한 톤을 더하면서도
+          폼/카드의 가독성은 해치지 않는 수준으로만 노출 */}
+      <div className="relative flex-1 overflow-hidden">
+        <div
+          aria-hidden
+          className="pointer-events-none absolute -top-20 right-0 size-[480px] rounded-full blur-3xl"
+          style={{ background: 'radial-gradient(circle, #DBEAFE 0%, transparent 70%)' }}
+        />
+        <div
+          aria-hidden
+          className="pointer-events-none absolute top-72 -left-32 size-[420px] rounded-full blur-3xl"
+          style={{ background: 'radial-gradient(circle, #EDE9FE 0%, transparent 70%)' }}
+        />
+
+        <div className="relative max-w-6xl mx-auto w-full px-6 py-10">
+          <button
+            onClick={() => navigate('/')}
+            className="cursor-pointer group flex items-center gap-1.5 text-sm text-slate-500 hover:text-slate-900 mb-10 transition-colors"
+          >
+            <CaretLeftIcon
+              weight="fill"
+              size={14}
+              className="group-hover:-translate-x-0.5 transition-transform"
+            />
+            Back to Map
+          </button>
+
+          <div className="max-w-2xl">
+            <div className="inline-flex items-center gap-2 mb-4 px-3 py-1 rounded-full bg-white ring-1 ring-slate-200/80 shadow-[0_1px_2px_rgb(15,23,42,0.04)]">
+              <span className="relative flex size-1.5">
+                <span className="absolute inline-flex size-full rounded-full bg-emerald-400 opacity-75 animate-ping" />
+                <span className="relative inline-flex rounded-full size-1.5 bg-emerald-500" />
+              </span>
+              <span className="text-[11px] font-semibold text-slate-700 tracking-tight">
+                실시간 혼잡도 안내
+              </span>
+            </div>
+
+            <h1 className="text-[40px] sm:text-[48px] font-semibold text-slate-900 tracking-[-0.03em] leading-[1.05]">
+              어디로 가볼까요?
+            </h1>
+            <p className="mt-3 text-[15px] text-slate-500 leading-relaxed">
+              핫플레이스까지 가는 가장 빠른 길,
+              <br className="hidden sm:block" /> 도착지의 지금 분위기와 함께 알려드려요.
+            </p>
+          </div>
+
+          <div className="mt-12 grid grid-cols-1 lg:grid-cols-[360px_1fr] gap-6">
+            <div className="bg-white rounded-3xl ring-1 ring-slate-100 p-6 h-fit lg:sticky lg:top-24 shadow-[0_4px_24px_-12px_rgb(15,23,42,0.08)] transition-shadow hover:shadow-[0_8px_32px_-12px_rgb(15,23,42,0.12)]">
+              <h2 className="text-sm font-semibold text-slate-900 tracking-tight mb-5">
+                경로 입력
+              </h2>
+
+              <div className="space-y-2.5">
+                <div>
+                  <label className="block text-xs font-medium text-slate-500 mb-1.5">
+                    출발지
+                  </label>
+                  <OriginSearchInput value={origin} onChange={handleOriginChange} />
+                </div>
+                <div>
+                  <label className="block text-xs font-medium text-slate-500 mb-1.5">
+                    도착지
+                  </label>
+                  <DestinationSelect value={destAreaCode} onChange={handleDestChange} />
+                </div>
+              </div>
+
+              <button
+                type="button"
+                onClick={handleSearch}
+                disabled={!canSearch || state.status === 'loading'}
+                className="cursor-pointer disabled:cursor-not-allowed mt-6 w-full py-3 rounded-xl bg-blue-600 text-white text-sm font-semibold hover:bg-blue-700 active:scale-[0.99] disabled:bg-slate-100 disabled:text-slate-400 transition-all flex items-center justify-center gap-1.5"
+              >
+                {state.status === 'loading' ? (
+                  <span>경로 찾는 중</span>
+                ) : (
+                  <>
+                    <span>경로 찾기</span>
+                    <ArrowRight className="size-4" strokeWidth={2} />
+                  </>
+                )}
+              </button>
+            </div>
+
+            <div className="space-y-4">
+              {destAreaCode && <DestinationPreviewCard areaCode={destAreaCode} />}
+
+              {state.status === 'idle' && (
+                <div className="bg-white rounded-3xl ring-1 ring-slate-100 py-16 px-6 flex flex-col items-center justify-center text-center shadow-[0_4px_24px_-16px_rgb(15,23,42,0.06)]">
+                  <RouteIllustration className="w-32 h-auto mb-6" />
+                  <p className="text-base font-semibold text-slate-900 tracking-tight">
+                    {destAreaCode ? '출발지만 알려주시면 돼요' : '어디서 출발하시나요?'}
+                  </p>
+                  <p className="mt-2 text-sm text-slate-500 max-w-xs leading-relaxed">
+                    도보 · 버스 · 지하철을 조합해
+                    <br />
+                    가장 빠른 길을 찾아드릴게요
+                  </p>
+                </div>
+              )}
+
+              {state.status === 'loading' && (
+                <div className="space-y-3">
+                  {Array.from({ length: 3 }).map((_, i) => (
+                    <div
+                      key={i}
+                      className="bg-white rounded-3xl ring-1 ring-slate-100 p-5 animate-pulse"
+                    >
+                      <div className="h-8 w-20 bg-slate-100 rounded-md" />
+                      <div className="mt-2.5 h-3 w-32 bg-slate-100 rounded" />
+                      <div className="mt-4 h-1 w-full bg-slate-100 rounded-full" />
+                      <div className="mt-3 flex gap-1.5">
+                        <div className="h-5 w-14 bg-slate-100 rounded-md" />
+                        <div className="h-5 w-12 bg-slate-100 rounded-md" />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {state.status === 'empty' && (
+                <div className="bg-white rounded-3xl ring-1 ring-slate-100 py-16 text-center">
+                  <p className="text-sm font-semibold text-slate-900">
+                    추천 가능한 경로가 없어요
+                  </p>
+                  <p className="mt-1.5 text-sm text-slate-500">
+                    출발지를 바꿔서 다시 시도해보세요
+                  </p>
+                </div>
+              )}
+
+              {state.status === 'error' && (
+                <div className="bg-white rounded-3xl ring-1 ring-slate-100 py-16 text-center">
+                  <p className="text-sm font-semibold text-slate-900">경로를 불러올 수 없어요</p>
+                  <p className="mt-1.5 text-sm text-slate-500">잠시 후 다시 시도해주세요</p>
+                </div>
+              )}
+
+              {state.status === 'success' && destAreaCode && origin && (
+                <>
+                  <div className="flex items-baseline justify-between px-1 pt-1">
+                    <p className="text-xs text-slate-500">
+                      경로{' '}
+                      <span className="font-semibold text-slate-900 tabular-nums">
+                        {sortedPaths.length}
+                      </span>
+                      개 · 빠른 순
+                    </p>
+                  </div>
+                  <div className="space-y-2.5">
+                    {sortedPaths.map((path, idx) => (
+                      <RoutePathCard
+                        key={idx}
+                        path={path}
+                        expanded={expandedIdx === idx}
+                        isFastest={idx === 0}
+                        destinationAreaCode={destAreaCode}
+                        originLabel={origin.label}
+                        destinationLabel={LOCATION_MAP.get(destAreaCode)?.name ?? '도착지'}
+                        onToggle={() => handleToggle(idx)}
+                        onDestinationClick={(areaCode) => navigate(`/place/${areaCode}`)}
+                      />
+                    ))}
+                  </div>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RoutePlannerPage;

--- a/src/types/kakao.d.ts
+++ b/src/types/kakao.d.ts
@@ -22,6 +22,26 @@ declare namespace kakao.maps {
       coord2Address(lng: number, lat: number, callback: Coord2AddressCallback): void;
     }
 
+    // Places: 키워드 기반 장소 검색 (services 라이브러리에 포함)
+    interface PlacesSearchResultItem {
+      id: string;
+      place_name: string;
+      address_name: string;
+      road_address_name: string;
+      x: string; // longitude (string으로 내려옴)
+      y: string; // latitude
+    }
+
+    type PlacesSearchCallback = (
+      result: PlacesSearchResultItem[],
+      status: string,
+      pagination: unknown,
+    ) => void;
+
+    class Places {
+      keywordSearch(query: string, callback: PlacesSearchCallback): void;
+    }
+
     const Status: {
       readonly OK: string;
       readonly ZERO_RESULT: string;

--- a/src/types/route.ts
+++ b/src/types/route.ts
@@ -1,0 +1,38 @@
+// 백엔드 GET /api/mobility/route (ODSAY 기반) 응답 타입
+// 구간 종류별로 nullable 필드가 달라짐 — WALK는 lane/stations/way 없음, SUBWAY는 busNo 없음 등
+
+export type TrafficType = 'WALK' | 'BUS' | 'SUBWAY';
+
+export interface RouteLane {
+  busNo: string | null;
+  type: number | null;
+  name: string | null;
+  subwayCode: number | null;
+}
+
+export interface RouteSubPath {
+  trafficType: TrafficType;
+  sectionTime: number;
+  intervalTime: number | null;
+  way: string | null;
+  lane: RouteLane[];
+  stations: string[] | null;
+}
+
+export interface RouteInfo {
+  totalTime: number;
+  payment: number;
+  busTransitCount: number;
+  subwayTransitCount: number;
+  firstStartStation: string;
+  lastEndStation: string;
+}
+
+export interface RoutePath {
+  info: RouteInfo;
+  subPaths: RouteSubPath[];
+}
+
+export interface TransitRouteResponse {
+  paths: RoutePath[];
+}

--- a/src/utils/kakaoSdk.ts
+++ b/src/utils/kakaoSdk.ts
@@ -1,0 +1,24 @@
+const SDK_WAIT_INTERVAL_MS = 100;
+const SDK_WAIT_MAX_TRIES = 30; // 100ms × 30 = 3초
+
+/**
+ * window.kakao SDK가 로드될 때까지 대기 후 kakao.maps.load 콜백으로 라이브러리 준비를 보장한다.
+ * services 라이브러리는 index.html의 SDK URL에 &libraries=services가 포함돼 있어야 함.
+ * 최대 시도 횟수 초과 시 onError를 호출해 무한 로딩 상태를 방지한다 (선택).
+ */
+export const waitForKakao = (cb: () => void, onError?: () => void): void => {
+  let tries = 0;
+  const tick = () => {
+    if (typeof window.kakao?.maps?.load === 'function') {
+      window.kakao.maps.load(cb);
+      return;
+    }
+    if (tries >= SDK_WAIT_MAX_TRIES) {
+      onError?.();
+      return;
+    }
+    tries += 1;
+    window.setTimeout(tick, SDK_WAIT_INTERVAL_MS);
+  };
+  tick();
+};


### PR DESCRIPTION
## 관련 이슈
Closes #47

> 출발지에서 핫플레이스까지의 대중교통 경로를 안내하는 Route Planner 페이지를 구현했습니다. 백엔드(`service-mobility`)의 ODSAY 기반 경로 조회 API를 연동했습니다.

## 변경 사항

### 경로 검색 페이지 (`/route`)
- ODSAY 기반 경로 조회 (`GET /api/mobility/route`) 연동
- 출발지: Kakao Places 자유 검색 (자동완성 + 250ms 디바운스)
- 도착지: 기존 핫스팟 목록에서 선택, 결과 카드의 도착지 클릭 시 상세페이지로 이동
- 결과 카드: 총 소요시간 / 요금 / 환승 수 / 모드 비율 바 / 사용 노선 칩
- 펼침 시: 출발 → 환승역 → 도착으로 이어지는 타임라인 (역=점, 구간=색 바, 도보=점선)
- 다중 경로는 totalTime 오름차순 정렬, 아코디언 토글
- 도착지 선택 시 해당 핫스팟의 실시간 혼잡도 + 이미지 미리보기 카드 노출 (서비스 차별점)

### 지하철 노선 색상
- 수도권 도시철도 공식 노선 색상 매핑 (`data/subwayLineColors.ts`) — 1호선 #0052A4, 2호선 #009D3E 등 24개 노선
- ProportionalBar · 노선 칩 · 타임라인 아이콘에 일괄 적용
- ODSAY 응답의 "수도권 " 접두어 자동 제거 (`cleanSubwayName`)

### 디자인
- Ambient gradient blob과 Pretendard 타이포로 페이지 톤 통일
- Empty state에 출발→도착 미니 일러스트 추가
- Fastest 카드는 파랑 ring + "최단 경로" 라벨로 강조
- 검색 버튼은 로고와 동일한 blue-600

### 리팩토링
- `useAddress`와 `OriginSearchInput`이 공유하던 `waitForKakao` SDK 대기 로직을 `utils/kakaoSdk.ts`로 추출
- `kakao.maps.services.Places` 타입 보강