### PR TITLE
feat: 모바일 랭킹 바텀시트 + 페이지 반응형 개선

### DIFF
--- a/src/components/congestion/CongestionLegend.tsx
+++ b/src/components/congestion/CongestionLegend.tsx
@@ -7,7 +7,7 @@ const LEGEND = [
 
 const CongestionLegend = () => {
   return (
-    <div className="absolute bottom-6 left-4 md:left-auto md:right-4 z-10 flex items-center gap-2 bg-white/95 backdrop-blur-sm rounded-2xl px-6 py-4 shadow-lg border border-gray-100">
+    <div className="absolute bottom-6 left-4 md:left-auto md:right-4 z-10 h-10 flex items-center gap-2 bg-white/95 backdrop-blur-sm rounded-2xl px-4 shadow-lg border border-gray-100">
       {LEGEND.map((item) => (
         <div key={item.label} className="flex items-center gap-1">
           <span className={`w-3 h-3 rounded-full ${item.color}`} />

--- a/src/components/congestion/CongestionRankCard.tsx
+++ b/src/components/congestion/CongestionRankCard.tsx
@@ -1,8 +1,5 @@
-import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { TrendingUp, TrendingDown, ArrowRight, GripVertical } from 'lucide-react';
-import axios from 'axios';
-import { fetchBusiestRanking, fetchRelaxedRanking } from '../../api/congestionApi';
 import { CONGESTION_LEVEL_MAP, CONGESTION_COLORS, CONGESTION_LABELS } from '../../types/congestion';
 import { useDraggable } from '../../hooks/useDraggable';
 import type { RankingEntry } from '../../types/congestion';
@@ -10,30 +7,14 @@ import type { RankingEntry } from '../../types/congestion';
 interface Props {
   type: 'busiest' | 'relaxed';
   initialRatio: { x: number; y: number };
+  entries: RankingEntry[];
+  loading: boolean;
+  error: boolean;
 }
 
-const CongestionRankCard = ({ type, initialRatio }: Props) => {
+const CongestionRankCard = ({ type, initialRatio, entries, loading, error }: Props) => {
   const navigate = useNavigate();
-  const [entries, setEntries] = useState<RankingEntry[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(false);
   const { ref, position, scale, isDragging, handleMouseDown } = useDraggable(initialRatio);
-
-  useEffect(() => {
-    const controller = new AbortController();
-    const loadData = type === 'busiest' ? fetchBusiestRanking : fetchRelaxedRanking;
-
-    loadData(3, controller.signal)
-      .then((data) => setEntries(data.rankings))
-      .catch((err) => {
-        if (!axios.isCancel(err)) setError(true);
-      })
-      .finally(() => {
-        if (!controller.signal.aborted) setLoading(false);
-      });
-
-    return () => controller.abort();
-  }, [type]);
 
   const isBusiest = type === 'busiest';
   const title = isBusiest ? 'Peak Congestion' : 'Quiet Getaways';
@@ -44,7 +25,7 @@ const CongestionRankCard = ({ type, initialRatio }: Props) => {
     <div
       ref={ref}
       onMouseDown={handleMouseDown}
-      className="rank-card-hint fixed z-10 bg-white rounded-2xl shadow-2xl border border-gray-200 p-5 w-[16vw] min-w-56 max-w-80 select-none"
+      className="rank-card-hint hidden md:block fixed z-10 bg-white rounded-2xl shadow-2xl border border-gray-200 p-5 w-[16vw] min-w-56 max-w-80 select-none"
       style={{
         left: 0,
         top: 0,
@@ -67,6 +48,8 @@ const CongestionRankCard = ({ type, initialRatio }: Props) => {
         </div>
       ) : error ? (
         <p className="text-xs text-gray-400 text-center py-2">데이터를 불러올 수 없습니다</p>
+      ) : entries.length === 0 ? (
+        <p className="text-xs text-gray-400 text-center py-2">표시할 랭킹이 없어요</p>
       ) : (
         <div className="space-y-3">
           {entries.map((entry, i) => {

--- a/src/components/congestion/RankingBottomSheet.tsx
+++ b/src/components/congestion/RankingBottomSheet.tsx
@@ -1,0 +1,212 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  TrendUpIcon,
+  TreeEvergreenIcon,
+  CaretUpIcon,
+  ArrowRightIcon,
+} from '@phosphor-icons/react';
+import type { Icon } from '@phosphor-icons/react';
+import {
+  CONGESTION_LEVEL_MAP,
+  CONGESTION_COLORS,
+  CONGESTION_LABELS,
+} from '../../types/congestion';
+import type { RankingEntry } from '../../types/congestion';
+import { useSwipeDown } from '../../hooks/useSwipeDown';
+
+const TOP_LIMIT = 3;
+const SHEET_ID = 'ranking-bottom-sheet';
+
+interface Props {
+  busiest: RankingEntry[];
+  relaxed: RankingEntry[];
+  loading: boolean;
+  error: boolean;
+}
+
+interface SectionProps {
+  title: string;
+  Icon: Icon;
+  iconColor: string;
+  tab: 'busiest' | 'relaxed';
+  entries: RankingEntry[];
+  loading: boolean;
+  error: boolean;
+  onItemSelect: (areaCode: string) => void;
+}
+
+const Section = ({
+  title,
+  Icon,
+  iconColor,
+  tab,
+  entries,
+  loading,
+  error,
+  onItemSelect,
+}: SectionProps) => {
+  const navigate = useNavigate();
+
+  return (
+    <section>
+      <div className="flex items-center gap-2 mb-2.5">
+        <Icon size={15} weight="fill" className={iconColor} />
+        <h2 className="text-[13px] font-semibold text-slate-900 tracking-tight">
+          {title}
+        </h2>
+      </div>
+
+      {loading ? (
+        <div className="space-y-1">
+          {Array.from({ length: TOP_LIMIT }).map((_, i) => (
+            <div key={i} className="h-9 bg-slate-50 rounded-lg animate-pulse" />
+          ))}
+        </div>
+      ) : error ? (
+        <p className="text-xs text-slate-400 text-center py-2">
+          데이터를 불러올 수 없습니다
+        </p>
+      ) : entries.length === 0 ? (
+        <p className="text-xs text-slate-400 text-center py-2">표시할 랭킹이 없어요</p>
+      ) : (
+        <ul>
+          {entries.map((entry, i) => {
+            const level = CONGESTION_LEVEL_MAP[entry.congestionLevel];
+            const color = level ? CONGESTION_COLORS[level] : '#9ca3af';
+            const label = level ? CONGESTION_LABELS[level] : entry.congestionLevel;
+            return (
+              <li key={entry.areaCode}>
+                <button
+                  type="button"
+                  onClick={() => onItemSelect(entry.areaCode)}
+                  className="cursor-pointer w-full flex items-center gap-3 py-2 -mx-2 px-2 rounded-lg active:bg-slate-50 transition-colors text-left"
+                >
+                  <span className="text-[13px] text-slate-300 tabular-nums w-4 shrink-0 font-medium">
+                    {i + 1}
+                  </span>
+                  <span className="flex-1 text-[14px] font-medium text-slate-900 tracking-tight truncate">
+                    {entry.areaName}
+                  </span>
+                  <span
+                    className="text-[10.5px] font-medium tracking-tight px-2 py-0.5 rounded-full text-white shrink-0"
+                    style={{ backgroundColor: color }}
+                  >
+                    {label}
+                  </span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <button
+        type="button"
+        onClick={() => navigate(`/ranking?tab=${tab}`)}
+        className="cursor-pointer group flex items-center justify-center gap-1 w-full mt-3 text-[12px] font-medium text-slate-400 hover:text-slate-700 transition-colors"
+      >
+        더 보기
+        <ArrowRightIcon
+          size={11}
+          weight="bold"
+          className="group-hover:translate-x-0.5 transition-transform"
+        />
+      </button>
+    </section>
+  );
+};
+
+const RankingBottomSheet = ({ busiest, relaxed, loading, error }: Props) => {
+  const navigate = useNavigate();
+  const [open, setOpen] = useState(false);
+  const { dragY, touchHandlers } = useSwipeDown({ onDismiss: () => setOpen(false) });
+
+  // 시트가 열려있을 때만 Escape 키 리스너 — 닫혔을 때는 등록도 안 해 불필요한 비용 회피.
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [open]);
+
+  const handleItemSelect = (areaCode: string) => {
+    setOpen(false);
+    navigate(`/place/${areaCode}`);
+  };
+
+  const dragging = dragY > 0;
+
+  return (
+    <div className="md:hidden">
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-label="혼잡도 랭킹 열기"
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        aria-controls={SHEET_ID}
+        className={`fixed bottom-6 right-4 z-20 cursor-pointer h-10 flex items-center gap-1.5 pl-3.5 pr-3 bg-white rounded-2xl ring-1 ring-slate-200/80 shadow-[0_4px_16px_rgba(15,23,42,0.08)] active:scale-[0.98] transition-[opacity,transform] duration-200 ${
+          open ? 'opacity-0 pointer-events-none' : 'opacity-100'
+        }`}
+      >
+        <TrendUpIcon size={14} weight="fill" className="text-rose-500" />
+        <span className="text-[13px] font-semibold text-slate-900 tracking-tight">
+          Rankings
+        </span>
+        <CaretUpIcon size={12} weight="bold" className="text-slate-400" />
+      </button>
+
+      <div
+        id={SHEET_ID}
+        role="dialog"
+        aria-label="혼잡도 랭킹"
+        aria-hidden={!open}
+        className={`fixed inset-x-0 bottom-0 z-20 bg-white rounded-t-[28px] shadow-[0_-8px_32px_rgba(15,23,42,0.1)] ring-1 ring-slate-900/5 ${
+          dragging ? '' : 'transition-transform duration-300 ease-out'
+        }`}
+        style={{
+          transform: open ? `translateY(${dragY}px)` : 'translateY(100%)',
+        }}
+      >
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          {...touchHandlers}
+          aria-label="시트 닫기"
+          className="cursor-pointer w-full flex justify-center pt-3 pb-2 touch-none"
+        >
+          <div className="w-9 h-1 bg-slate-200 rounded-full" />
+        </button>
+
+        <div className="px-6 pt-2 pb-7 space-y-5">
+          <Section
+            title="Peak Congestion"
+            Icon={TrendUpIcon}
+            iconColor="text-rose-500"
+            tab="busiest"
+            entries={busiest}
+            loading={loading}
+            error={error}
+            onItemSelect={handleItemSelect}
+          />
+          <div className="h-px bg-slate-100" />
+          <Section
+            title="Quiet Getaways"
+            Icon={TreeEvergreenIcon}
+            iconColor="text-emerald-600"
+            tab="relaxed"
+            entries={relaxed}
+            loading={loading}
+            error={error}
+            onItemSelect={handleItemSelect}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RankingBottomSheet;

--- a/src/components/congestion/RankingBottomSheet.tsx
+++ b/src/components/congestion/RankingBottomSheet.tsx
@@ -173,8 +173,13 @@ const RankingBottomSheet = ({ busiest, relaxed, loading, error }: Props) => {
       >
         <button
           type="button"
-          onClick={() => setOpen(false)}
           {...touchHandlers}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              setOpen(false);
+            }
+          }}
           aria-label="시트 닫기"
           className="cursor-pointer w-full flex justify-center pt-3 pb-2 touch-none"
         >

--- a/src/components/detail/AiInsightCard.tsx
+++ b/src/components/detail/AiInsightCard.tsx
@@ -32,14 +32,14 @@ const AiInsightCard = ({ areaCode }: Props) => {
       {state.status === 'stale' && <PlaceholderCard message={AI_STATE_MESSAGES.stale} />}
       {state.status === 'error' && <PlaceholderCard message={AI_STATE_MESSAGES.error} />}
       {state.status === 'success' && (
-        <div className="relative overflow-hidden rounded-2xl shadow-sm border border-slate-100 bg-white px-8 sm:px-12 py-10 sm:py-12">
+        <div className="relative overflow-hidden rounded-2xl shadow-sm border border-slate-100 bg-white px-6 sm:px-8 lg:px-12 py-8 sm:py-10 lg:py-12">
           <div
             className="pointer-events-none absolute -top-24 -right-24 w-72 h-72 rounded-full bg-gradient-to-br from-blue-300/25 to-blue-100/10 blur-3xl"
             aria-hidden
           />
 
           <span
-            className="pointer-events-none select-none absolute -left-2 -top-8 text-[140px] font-extrabold text-blue-100 leading-none"
+            className="pointer-events-none select-none absolute -left-2 -top-8 text-[100px] sm:text-[140px] font-extrabold text-blue-100 leading-none"
             aria-hidden
           >
             &ldquo;

--- a/src/components/detail/CongestionHeroCard.tsx
+++ b/src/components/detail/CongestionHeroCard.tsx
@@ -32,7 +32,7 @@ const CongestionHeroCard = ({
         }}
       />
     </div>
-    <div className="p-8 sm:p-10">
+    <div className="p-6 sm:p-8 lg:p-10">
       <div className="flex items-start justify-between gap-6">
         <div className="min-w-0 flex-1">
           <p className="text-[11px] font-medium tracking-[0.08em] text-slate-500 mb-3">
@@ -57,7 +57,7 @@ const CongestionHeroCard = ({
           Current Visitors
         </p>
         <div className="flex items-baseline gap-1.5">
-          <p className="text-5xl font-extrabold text-slate-900 tracking-[-0.04em] tabular-nums">
+          <p className="text-4xl sm:text-5xl font-extrabold text-slate-900 tracking-[-0.04em] tabular-nums">
             {avgPeople.toLocaleString()}
           </p>
           <p className="text-lg font-light text-slate-400">명</p>

--- a/src/hooks/useSwipeDown.ts
+++ b/src/hooks/useSwipeDown.ts
@@ -5,13 +5,17 @@ interface Options {
   onDismiss: () => void;
 }
 
-// 바텀시트 등에서 "아래로 끌어 닫기" 제스처를 처리. dragY는 현재 드래그 오프셋(px)으로
-// 호출 측에서 transform에 반영하면 손가락에 즉시 따라붙고, 손을 떼는 시점에 threshold를
-// 넘었으면 onDismiss 호출, 안 넘었으면 0으로 스냅백.
+const TAP_SLOP = 5;
+
+// 바텀시트 등에서 "아래로 끌어 닫기" 제스처를 처리.
+// - dragY: 현재 드래그 오프셋(px). 호출 측이 transform에 반영하면 손가락을 따라옴
+// - 손가락이 시작점보다 위로 가도 0으로 클램프해 시트가 시작 위치 위로 솟지 않게 함
+// - touchEnd 시 이동량이 TAP_SLOP 미만이면 탭으로 판정해 onDismiss
+// - 이동량이 threshold를 넘으면 드래그-닫기로 onDismiss
+// - 그 사이(부분 드래그)면 0으로 스냅백
 //
-// dragY는 state와 ref 둘 다 들고 있다: state는 transform 리렌더용, ref는 onTouchEnd가
-// 빠른 스와이프 상황(touchmove→touchend가 React 리렌더 사이에 일어남)에서도 최신 값을
-// 읽도록 보장하기 위한 것. ref 없이 state만 읽으면 stale 값을 보고 dismiss 누락 가능.
+// state와 ref를 같이 들고 있는 이유: 빠른 스와이프에서 touchmove → touchend가 React
+// 리렌더 사이에 일어나면 state 기반 closure는 stale 값을 보게 됨. ref로 항상 최신 값 읽음.
 export const useSwipeDown = ({ threshold = 80, onDismiss }: Options) => {
   const [dragY, setDragY] = useState(0);
   const dragYRef = useRef(0);
@@ -29,10 +33,13 @@ export const useSwipeDown = ({ threshold = 80, onDismiss }: Options) => {
     onTouchMove: (e: React.TouchEvent) => {
       if (startYRef.current == null) return;
       const dy = e.touches[0].clientY - startYRef.current;
-      if (dy > 0) updateDragY(dy);
+      updateDragY(Math.max(0, dy));
     },
     onTouchEnd: () => {
-      if (dragYRef.current > threshold) onDismiss();
+      const movement = dragYRef.current;
+      const isTap = movement < TAP_SLOP;
+      const passedThreshold = movement > threshold;
+      if (isTap || passedThreshold) onDismiss();
       updateDragY(0);
       startYRef.current = null;
     },

--- a/src/hooks/useSwipeDown.ts
+++ b/src/hooks/useSwipeDown.ts
@@ -1,0 +1,42 @@
+import { useRef, useState } from 'react';
+
+interface Options {
+  threshold?: number;
+  onDismiss: () => void;
+}
+
+// 바텀시트 등에서 "아래로 끌어 닫기" 제스처를 처리. dragY는 현재 드래그 오프셋(px)으로
+// 호출 측에서 transform에 반영하면 손가락에 즉시 따라붙고, 손을 떼는 시점에 threshold를
+// 넘었으면 onDismiss 호출, 안 넘었으면 0으로 스냅백.
+//
+// dragY는 state와 ref 둘 다 들고 있다: state는 transform 리렌더용, ref는 onTouchEnd가
+// 빠른 스와이프 상황(touchmove→touchend가 React 리렌더 사이에 일어남)에서도 최신 값을
+// 읽도록 보장하기 위한 것. ref 없이 state만 읽으면 stale 값을 보고 dismiss 누락 가능.
+export const useSwipeDown = ({ threshold = 80, onDismiss }: Options) => {
+  const [dragY, setDragY] = useState(0);
+  const dragYRef = useRef(0);
+  const startYRef = useRef<number | null>(null);
+
+  const updateDragY = (value: number) => {
+    dragYRef.current = value;
+    setDragY(value);
+  };
+
+  const touchHandlers = {
+    onTouchStart: (e: React.TouchEvent) => {
+      startYRef.current = e.touches[0].clientY;
+    },
+    onTouchMove: (e: React.TouchEvent) => {
+      if (startYRef.current == null) return;
+      const dy = e.touches[0].clientY - startYRef.current;
+      if (dy > 0) updateDragY(dy);
+    },
+    onTouchEnd: () => {
+      if (dragYRef.current > threshold) onDismiss();
+      updateDragY(0);
+      startYRef.current = null;
+    },
+  };
+
+  return { dragY, touchHandlers };
+};

--- a/src/hooks/useTopRankings.ts
+++ b/src/hooks/useTopRankings.ts
@@ -1,0 +1,63 @@
+import { useEffect, useReducer } from 'react';
+import axios from 'axios';
+import { fetchBusiestRanking, fetchRelaxedRanking } from '../api/congestionApi';
+import type { RankingEntry } from '../types/congestion';
+
+type State = {
+  busiest: RankingEntry[];
+  relaxed: RankingEntry[];
+  loading: boolean;
+  error: boolean;
+};
+
+type Action =
+  | { type: 'success'; busiest: RankingEntry[]; relaxed: RankingEntry[] }
+  | { type: 'error' };
+
+function topRankingsReducer(state: State, action: Action): State {
+  switch (action.type) {
+    case 'success':
+      return {
+        busiest: action.busiest,
+        relaxed: action.relaxed,
+        loading: false,
+        error: false,
+      };
+    case 'error':
+      return { ...state, loading: false, error: true };
+  }
+}
+
+// busiest/relaxed 두 랭킹을 한 번에 가져와 미리보기 카드/시트에서 같이 쓰도록 만든 hook.
+// 단일 useRanking은 limit=122 고정이라 top N 미리보기 용도엔 부적합 — limit를 인자로 받는다.
+export const useTopRankings = (limit: number) => {
+  const [state, dispatch] = useReducer(topRankingsReducer, {
+    busiest: [],
+    relaxed: [],
+    loading: true,
+    error: false,
+  });
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    Promise.all([
+      fetchBusiestRanking(limit, controller.signal),
+      fetchRelaxedRanking(limit, controller.signal),
+    ])
+      .then(([b, r]) => {
+        if (!controller.signal.aborted) {
+          dispatch({ type: 'success', busiest: b.rankings, relaxed: r.rankings });
+        }
+      })
+      .catch((err) => {
+        if (!axios.isCancel(err)) {
+          dispatch({ type: 'error' });
+        }
+      });
+
+    return () => controller.abort();
+  }, [limit]);
+
+  return state;
+};

--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -52,7 +52,7 @@ const DetailPage = () => {
   return (
     <div className="flex flex-col w-full min-h-dvh bg-slate-50">
       <Header onSearchSelect={(areaCode) => navigate(`/place/${areaCode}`)} />
-      <div className="max-w-6xl mx-auto w-full px-6 py-6">
+      <div className="max-w-6xl mx-auto w-full px-4 sm:px-6 py-4 sm:py-6">
         <button
           onClick={() => navigate('/')}
           className="cursor-pointer group flex items-center gap-1.5 text-sm text-slate-500 hover:text-slate-900 mb-6 transition-colors"

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -6,9 +6,11 @@ import CategoryFilter from '../components/filter/CategoryFilter';
 import MapControls from '../components/map/MapControls';
 import CongestionLegend from '../components/congestion/CongestionLegend';
 import CongestionRankCard from '../components/congestion/CongestionRankCard';
+import RankingBottomSheet from '../components/congestion/RankingBottomSheet';
 import AlternativeLocationBanner from '../components/map/AlternativeLocationBanner';
 import { fetchAlternativeLocations } from '../api/mapApi';
 import { useMapControls } from '../hooks/useMapControls';
+import { useTopRankings } from '../hooks/useTopRankings';
 import { LOCATION_MAP } from '../data/locations';
 import type { AlternativeLocation } from '../types/map';
 import type { PlaceMarker } from '../types/congestion';
@@ -24,6 +26,9 @@ const HomePage = () => {
   const [searchFocus, setSearchFocus] = useState<{ areaCode: string; nonce: number } | null>(null);
   const abortRef = useRef<AbortController | null>(null);
   const { setMap, zoomIn, zoomOut, locate, panTo, userLocation } = useMapControls();
+  // top3 랭킹은 한 번만 fetch해서 데스크탑 카드 2개와 모바일 바텀시트가 같이 사용.
+  // 각 컴포넌트가 자체 fetch하면 동일 endpoint를 4번 호출하게 됨.
+  const rankings = useTopRankings(3);
 
   const handleSearchSelect = useCallback(
     (areaCode: string) => {
@@ -81,8 +86,26 @@ const HomePage = () => {
         <CategoryFilter selected={selectedCategory} onSelect={setSelectedCategory} />
         <MapControls onZoomIn={zoomIn} onZoomOut={zoomOut} onLocate={locate} />
         <CongestionLegend />
-        <CongestionRankCard type="busiest" initialRatio={{ x: 1, y: 0.13 }} />
-        <CongestionRankCard type="relaxed" initialRatio={{ x: 1, y: 0.4 }} />
+        <CongestionRankCard
+          type="busiest"
+          initialRatio={{ x: 1, y: 0.13 }}
+          entries={rankings.busiest}
+          loading={rankings.loading}
+          error={rankings.error}
+        />
+        <CongestionRankCard
+          type="relaxed"
+          initialRatio={{ x: 1, y: 0.4 }}
+          entries={rankings.relaxed}
+          loading={rankings.loading}
+          error={rankings.error}
+        />
+        <RankingBottomSheet
+          busiest={rankings.busiest}
+          relaxed={rankings.relaxed}
+          loading={rankings.loading}
+          error={rankings.error}
+        />
       </div>
     </div>
   );

--- a/src/pages/HotspotsPage.tsx
+++ b/src/pages/HotspotsPage.tsx
@@ -1,6 +1,11 @@
 import { useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { TrendingUp, Search, ChevronLeft, ChevronRight } from 'lucide-react';
+import {
+  TrendUpIcon,
+  MagnifyingGlassIcon,
+  CaretLeftIcon,
+  CaretRightIcon,
+} from '@phosphor-icons/react';
 import Header from '../components/layout/Header';
 import { getLocationImageUrl } from '../data/locations';
 import { CATEGORY_NAMES, CATEGORY_FILTERS } from '../data/categories';
@@ -41,27 +46,33 @@ const HotspotsPage = () => {
   return (
     <div className="flex flex-col w-full min-h-dvh bg-gray-50">
       <Header />
-      <div className="max-w-7xl mx-auto w-full px-6 py-8">
+      <div className="max-w-7xl mx-auto w-full px-4 sm:px-6 py-6 sm:py-8">
         <div className="flex items-start justify-between mb-6">
-          <div>
+          <div className="min-w-0">
             <div className="flex items-center gap-2 mb-1">
-              <TrendingUp size={22} className="text-blue-600" />
-              <h1 className="text-3xl font-bold text-gray-900">서울 핫플레이스</h1>
+              <TrendUpIcon size={20} weight="fill" className="text-blue-600" />
+              <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 tracking-tight">
+                서울 핫플레이스
+              </h1>
             </div>
-            <p className="text-base text-gray-500">
+            <p className="text-sm sm:text-base text-gray-500">
               서울 주요 핫플레이스{' '}
               <span className="text-blue-600 font-medium">{filteredCount}곳</span>의 정보를
               제공합니다
             </p>
           </div>
-          <div className="flex items-center gap-1.5 text-sm text-green-500 font-medium mt-1">
+          <div className="hidden sm:flex items-center gap-1.5 text-sm text-green-500 font-medium mt-1 shrink-0">
             <span className="w-2 h-2 rounded-full bg-green-500 animate-pulse" />
             실시간
           </div>
         </div>
 
         <div className="relative mb-4">
-          <Search size={16} className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400" />
+          <MagnifyingGlassIcon
+            size={16}
+            weight="bold"
+            className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400"
+          />
           <input
             type="text"
             value={inputValue}
@@ -107,7 +118,7 @@ const HotspotsPage = () => {
                     <img
                       src={getLocationImageUrl(loc.name)}
                       alt={loc.name}
-                      className="w-full h-52 object-cover"
+                      className="w-full h-44 sm:h-52 object-cover"
                       onError={(e) => {
                         e.currentTarget.style.visibility = 'hidden';
                       }}
@@ -116,8 +127,10 @@ const HotspotsPage = () => {
                       {CATEGORY_NAMES[loc.category]}
                     </span>
                   </div>
-                  <div className="p-5">
-                    <h2 className="text-lg font-bold text-gray-900 mb-2">{loc.name}</h2>
+                  <div className="p-4 sm:p-5">
+                    <h2 className="text-base sm:text-lg font-bold text-gray-900 mb-2 tracking-tight">
+                      {loc.name}
+                    </h2>
                     <span className="text-sm text-blue-500 font-medium">
                       #{CATEGORY_NAMES[loc.category]}
                     </span>
@@ -134,7 +147,7 @@ const HotspotsPage = () => {
                   disabled={currentPage === 1}
                   className="cursor-pointer p-2 rounded-lg text-gray-400 hover:bg-gray-100 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
                 >
-                  <ChevronLeft size={18} />
+                  <CaretLeftIcon size={16} weight="bold" />
                 </button>
 
                 {pageNumbers.map((page, i) =>
@@ -167,7 +180,7 @@ const HotspotsPage = () => {
                   disabled={currentPage === totalPages}
                   className="cursor-pointer p-2 rounded-lg text-gray-400 hover:bg-gray-100 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
                 >
-                  <ChevronRight size={18} />
+                  <CaretRightIcon size={16} weight="bold" />
                 </button>
               </div>
             )}

--- a/src/pages/RankingPage.tsx
+++ b/src/pages/RankingPage.tsx
@@ -40,12 +40,13 @@ const RankingItem = ({ entry, onClick, focusNonce }: RankingItemProps) => {
       type="button"
       onClick={onClick}
       onAnimationEnd={handleHighlightEnd}
-      className={`w-full text-left cursor-pointer px-7 py-5 flex items-baseline gap-6 hover:bg-slate-50/70 transition-colors ${
+
+      className={`w-full text-left cursor-pointer px-5 sm:px-7 py-4 sm:py-5 flex items-baseline gap-4 sm:gap-6 hover:bg-slate-50/70 transition-colors ${
         shouldHighlight ? 'ranking-highlight' : ''
       }`}
     >
       <span
-        className={`text-4xl font-extrabold tabular-nums tracking-tight w-12 shrink-0 leading-none ${
+        className={`text-3xl sm:text-4xl font-extrabold tabular-nums tracking-tight w-10 sm:w-12 shrink-0 leading-none ${
           entry.rank === 1
             ? 'text-amber-500'
             : entry.rank === 2
@@ -59,7 +60,7 @@ const RankingItem = ({ entry, onClick, focusNonce }: RankingItemProps) => {
       </span>
 
       <div className="flex-1 min-w-0 self-center">
-        <p className="text-lg font-bold text-slate-900 tracking-tight truncate">
+        <p className="text-base sm:text-lg font-bold text-slate-900 tracking-tight truncate">
           {entry.areaName}
         </p>
         <p className="mt-1 text-sm text-slate-500">
@@ -109,10 +110,10 @@ const RankingPage = () => {
   return (
     <div className="flex flex-col w-full min-h-dvh bg-slate-50">
       <Header onSearchSelect={handleSearchSelect} />
-      <div className="max-w-6xl mx-auto w-full px-6 py-10">
+      <div className="max-w-6xl mx-auto w-full px-4 sm:px-6 py-6 sm:py-10">
         <button
           onClick={() => navigate('/')}
-          className="cursor-pointer group flex items-center gap-1.5 text-sm text-slate-500 hover:text-slate-900 mb-8 transition-colors"
+          className="cursor-pointer group flex items-center gap-1.5 text-sm text-slate-500 hover:text-slate-900 mb-6 sm:mb-8 transition-colors"
         >
           <CaretLeftIcon
             weight="fill"
@@ -147,7 +148,7 @@ const RankingPage = () => {
           )}
         </div>
 
-        <div className="mt-8 inline-flex gap-1 p-1 bg-slate-100/80 rounded-full">
+        <div className="mt-6 sm:mt-8 inline-flex gap-1 p-1 bg-slate-100/80 rounded-full">
           <button
             onClick={() => handleTabChange('busiest')}
             className={`cursor-pointer px-5 py-2 text-sm font-semibold tracking-tight rounded-full transition ${
@@ -174,7 +175,7 @@ const RankingPage = () => {
           {loading && (
             <div className="divide-y divide-slate-100">
               {Array.from({ length: 5 }).map((_, i) => (
-                <div key={i} className="h-20 animate-pulse" />
+                <div key={i} className="h-16 sm:h-20 animate-pulse" />
               ))}
             </div>
           )}

--- a/src/pages/RoutePlannerPage.tsx
+++ b/src/pages/RoutePlannerPage.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { CaretLeftIcon } from '@phosphor-icons/react';
-import { ArrowRight } from 'lucide-react';
+import { CaretLeftIcon, ArrowRightIcon } from '@phosphor-icons/react';
 import Header from '../components/layout/Header';
 import OriginSearchInput from '../components/route/OriginSearchInput';
 import type { OriginSelection } from '../components/route/OriginSearchInput';
@@ -70,10 +69,10 @@ const RoutePlannerPage = () => {
           style={{ background: 'radial-gradient(circle, #EDE9FE 0%, transparent 70%)' }}
         />
 
-        <div className="relative max-w-6xl mx-auto w-full px-6 py-10">
+        <div className="relative max-w-6xl mx-auto w-full px-4 sm:px-6 py-6 sm:py-10">
           <button
             onClick={() => navigate('/')}
-            className="cursor-pointer group flex items-center gap-1.5 text-sm text-slate-500 hover:text-slate-900 mb-10 transition-colors"
+            className="cursor-pointer group flex items-center gap-1.5 text-sm text-slate-500 hover:text-slate-900 mb-6 sm:mb-10 transition-colors"
           >
             <CaretLeftIcon
               weight="fill"
@@ -94,7 +93,7 @@ const RoutePlannerPage = () => {
               </span>
             </div>
 
-            <h1 className="text-[40px] sm:text-[48px] font-semibold text-slate-900 tracking-[-0.03em] leading-[1.05]">
+            <h1 className="text-[32px] sm:text-[48px] font-semibold text-slate-900 tracking-[-0.03em] leading-[1.05]">
               어디로 가볼까요?
             </h1>
             <p className="mt-3 text-[15px] text-slate-500 leading-relaxed">
@@ -103,8 +102,8 @@ const RoutePlannerPage = () => {
             </p>
           </div>
 
-          <div className="mt-12 grid grid-cols-1 lg:grid-cols-[360px_1fr] gap-6">
-            <div className="bg-white rounded-3xl ring-1 ring-slate-100 p-6 h-fit lg:sticky lg:top-24 shadow-[0_4px_24px_-12px_rgb(15,23,42,0.08)] transition-shadow hover:shadow-[0_8px_32px_-12px_rgb(15,23,42,0.12)]">
+          <div className="mt-8 sm:mt-12 grid grid-cols-1 lg:grid-cols-[360px_1fr] gap-6">
+            <div className="bg-white rounded-3xl ring-1 ring-slate-100 p-5 sm:p-6 h-fit lg:sticky lg:top-24 shadow-[0_4px_24px_-12px_rgb(15,23,42,0.08)] transition-shadow hover:shadow-[0_8px_32px_-12px_rgb(15,23,42,0.12)]">
               <h2 className="text-sm font-semibold text-slate-900 tracking-tight mb-5">
                 경로 입력
               </h2>
@@ -135,7 +134,7 @@ const RoutePlannerPage = () => {
                 ) : (
                   <>
                     <span>경로 찾기</span>
-                    <ArrowRight className="size-4" strokeWidth={2} />
+                    <ArrowRightIcon className="size-4" weight="bold" />
                   </>
                 )}
               </button>
@@ -145,7 +144,7 @@ const RoutePlannerPage = () => {
               {destAreaCode && <DestinationPreviewCard areaCode={destAreaCode} />}
 
               {state.status === 'idle' && (
-                <div className="bg-white rounded-3xl ring-1 ring-slate-100 py-16 px-6 flex flex-col items-center justify-center text-center shadow-[0_4px_24px_-16px_rgb(15,23,42,0.06)]">
+                <div className="bg-white rounded-3xl ring-1 ring-slate-100 py-12 sm:py-16 px-6 flex flex-col items-center justify-center text-center shadow-[0_4px_24px_-16px_rgb(15,23,42,0.06)]">
                   <RouteIllustration className="w-32 h-auto mb-6" />
                   <p className="text-base font-semibold text-slate-900 tracking-tight">
                     {destAreaCode ? '출발지만 알려주시면 돼요' : '어디서 출발하시나요?'}
@@ -178,7 +177,7 @@ const RoutePlannerPage = () => {
               )}
 
               {state.status === 'empty' && (
-                <div className="bg-white rounded-3xl ring-1 ring-slate-100 py-16 text-center">
+                <div className="bg-white rounded-3xl ring-1 ring-slate-100 py-12 sm:py-16 text-center">
                   <p className="text-sm font-semibold text-slate-900">
                     추천 가능한 경로가 없어요
                   </p>
@@ -189,7 +188,7 @@ const RoutePlannerPage = () => {
               )}
 
               {state.status === 'error' && (
-                <div className="bg-white rounded-3xl ring-1 ring-slate-100 py-16 text-center">
+                <div className="bg-white rounded-3xl ring-1 ring-slate-100 py-12 sm:py-16 text-center">
                   <p className="text-sm font-semibold text-slate-900">경로를 불러올 수 없어요</p>
                   <p className="mt-1.5 text-sm text-slate-500">잠시 후 다시 시도해주세요</p>
                 </div>


### PR DESCRIPTION
## 관련 이슈
#41

> 메인 페이지 드래그 랭킹 카드가 모바일에서 화면을 가리는 문제를 바텀시트 패턴으로 해결하고, 다른 페이지의 모바일 디테일도 같이 정리했습니다.

## 변경 사항

### 메인 페이지 모바일 랭킹 바텀시트

*   우하단 "Rankings" pill 탭 시 Peak Congestion / Quiet Getaways top 3 시트가 올라오도록 구현
*   핸들 탭, 아래로 스와이프, Escape 키로 닫히도록 처리
*   백드롭을 두지 않아 시트 위 맵 영역은 계속 조작 가능
*   데스크탑(md+)은 기존 드래그 카드 그대로 유지해 회귀 없음

### 리팩토링

*   `useTopRankings` hook으로 busiest/relaxed fetch를 한 번에 처리하고 HomePage에서 호출해 카드 2개·시트가 공유하도록 구성. 동일 endpoint 호출이 4회 → 2회로 감소
*   `useSwipeDown` hook으로 스와이프-다운 제스처를 분리하고, state + ref를 같이 들어 빠른 스와이프에서도 stale 값 없이 판정되도록 구현
*   `CongestionRankCard`는 fetch 책임을 제거하고 props만 받는 dumb 컴포넌트로 슬림화

### 접근성

*   트리거에 `aria-expanded` / `aria-haspopup` / `aria-controls`, 시트에 `role="dialog"` 부여
*   열렸을 때만 Escape 리스너가 등록되도록 구현
*   빈 데이터 상태 메시지 추가

### 페이지별 모바일 반응형 정리

*   **HotspotsPage / RoutePlannerPage**: lucide 아이콘을 phosphor로 통일하고 컨테이너 패딩·타이틀·카드 크기를 모바일 우선으로 스케일링
*   **RankingPage**: 아이템 패딩과 랭킹 숫자 사이즈를 모바일 기준으로 조정
*   **DetailPage**: 히어로 카드와 AI 인사이트 카드의 패딩·텍스트 사이즈를 모바일 우선으로 정리
