### PR TITLE
fix: useCongestionMarkers 외 혼잡도 hook 폴링 누락 보완

### DIFF
--- a/src/hooks/useAlternativeLocations.ts
+++ b/src/hooks/useAlternativeLocations.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import axios from 'axios';
 import { fetchAlternativeLocations } from '../api/mapApi';
 import type { AlternativeLocation } from '../types/map';
 
@@ -25,17 +26,18 @@ export const useAlternativeLocations = (areaCode: string | null) => {
     setState({ status: 'loading' });
     hasLoadedRef.current = false;
 
+    const controller = new AbortController();
     let timer: ReturnType<typeof setTimeout> | null = null;
     let cancelled = false;
 
     const load = async () => {
       try {
-        const data = await fetchAlternativeLocations(areaCode);
-        if (cancelled) return;
+        const data = await fetchAlternativeLocations(areaCode, controller.signal);
+        if (cancelled || controller.signal.aborted) return;
         setState(data.length === 0 ? { status: 'empty' } : { status: 'success', data });
         hasLoadedRef.current = true;
       } catch (err) {
-        if (cancelled) return;
+        if (cancelled || controller.signal.aborted || axios.isCancel(err)) return;
         // 폴링 중 일시 실패는 직전 데이터 유지, 첫 load 실패만 error 노출
         if (!hasLoadedRef.current) {
           setState({ status: 'error' });
@@ -56,6 +58,7 @@ export const useAlternativeLocations = (areaCode: string | null) => {
 
     return () => {
       cancelled = true;
+      controller.abort();
       if (timer) clearTimeout(timer);
     };
   }, [areaCode]);

--- a/src/hooks/useAlternativeLocations.ts
+++ b/src/hooks/useAlternativeLocations.ts
@@ -1,7 +1,11 @@
-import { useEffect, useState } from 'react';
-import axios from 'axios';
+import { useEffect, useRef, useState } from 'react';
 import { fetchAlternativeLocations } from '../api/mapApi';
 import type { AlternativeLocation } from '../types/map';
+
+// 백엔드 응답(AlternativeLocation[])에 시각 정보가 없어 useCongestionMarkers의 changed 판정
+// (populationTime 비교)을 적용할 수 없으므로 5분 고정 폴링으로 fallback한다.
+// 응답 스키마 보강(populationTime 추가)은 별도 백엔드 이슈로 분리.
+const POLL_INTERVAL = 5 * 60 * 1000;
 
 type State =
   | { status: 'loading' }
@@ -11,6 +15,7 @@ type State =
 
 export const useAlternativeLocations = (areaCode: string | null) => {
   const [state, setState] = useState<State>({ status: 'loading' });
+  const hasLoadedRef = useRef<boolean>(false);
 
   useEffect(() => {
     if (!areaCode) return;
@@ -18,19 +23,41 @@ export const useAlternativeLocations = (areaCode: string | null) => {
     // 다른 장소로 이동했을 때 이전 대체장소 목록이 잠깐 노출되는 stale 표시 방지
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setState({ status: 'loading' });
+    hasLoadedRef.current = false;
 
-    const controller = new AbortController();
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let cancelled = false;
 
-    fetchAlternativeLocations(areaCode, controller.signal)
-      .then((data) => {
-        if (controller.signal.aborted) return;
+    const load = async () => {
+      try {
+        const data = await fetchAlternativeLocations(areaCode);
+        if (cancelled) return;
         setState(data.length === 0 ? { status: 'empty' } : { status: 'success', data });
-      })
-      .catch((err) => {
-        if (!axios.isCancel(err)) setState({ status: 'error' });
-      });
+        hasLoadedRef.current = true;
+      } catch (err) {
+        if (cancelled) return;
+        // 폴링 중 일시 실패는 직전 데이터 유지, 첫 load 실패만 error 노출
+        if (!hasLoadedRef.current) {
+          setState({ status: 'error' });
+        } else {
+          console.error('[useAlternativeLocations] 폴링 중 로드 실패:', err);
+        }
+      }
+    };
 
-    return () => controller.abort();
+    const tick = async () => {
+      if (cancelled) return;
+      await load();
+      if (cancelled) return;
+      timer = setTimeout(tick, POLL_INTERVAL);
+    };
+
+    tick();
+
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
   }, [areaCode]);
 
   return state;

--- a/src/hooks/useDestinationCongestion.ts
+++ b/src/hooks/useDestinationCongestion.ts
@@ -1,6 +1,11 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { fetchCongestionByAreaCode } from '../api/congestionApi';
 import type { CongestionData } from '../types/congestion';
+
+// 백엔드가 5분 주기로 갱신되므로 새 데이터 받은 직후엔 5분 동안 새 데이터 없음.
+// 같은 데이터 받은 경우(백엔드 갱신 직전 폴링)만 짧게 재시도해 다음 갱신을 따라잡는다.
+const FRESH_INTERVAL = 5 * 60 * 1000; // 5분
+const RETRY_INTERVAL = 60 * 1000; // 60초
 
 type State =
   | { status: 'idle' }
@@ -12,31 +17,65 @@ type State =
  * Route Planner의 도착지 미리보기에서 사용. 선택된 핫스팟의 현재 혼잡도를 조회한다.
  * 서비스 핵심 가치(실시간 혼잡도)를 경로 결과 화면에서 직접 노출해 일반 길찾기 앱과의
  * 차별점을 만든다.
+ *
+ * useCongestionMarkers와 동일한 adaptive 폴링으로 5분 갱신 주기와 동기화한다.
  */
 export const useDestinationCongestion = (areaCode: string | null): State => {
   const [state, setState] = useState<State>({ status: 'idle' });
+  const prevPopulationTimeRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!areaCode) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setState({ status: 'idle' });
+      prevPopulationTimeRef.current = null;
       return;
     }
 
     // 다른 도착지로 바꿨을 때 이전 데이터가 잠깐 노출되는 stale 표시 방지
     setState({ status: 'loading' });
+    prevPopulationTimeRef.current = null;
 
+    let timer: ReturnType<typeof setTimeout> | null = null;
     let cancelled = false;
-    fetchCongestionByAreaCode(areaCode)
-      .then((data) => {
-        if (!cancelled) setState({ status: 'success', data });
-      })
-      .catch(() => {
-        if (!cancelled) setState({ status: 'error' });
-      });
+
+    // populationTime이 직전과 다르면 새 데이터로 보고 setState.
+    // 반환값으로 "백엔드 갱신 위상과 동기화됐는지"를 알려 호출자가 다음 폴링 주기를 결정한다.
+    // 첫 load는 백엔드 갱신 직후라는 보장이 없어 false 반환 → 60초 후 재시도로 위상 동기화.
+    const load = async (): Promise<boolean> => {
+      try {
+        const data = await fetchCongestionByAreaCode(areaCode);
+        if (cancelled) return false;
+        const latestTime = data.populationTime;
+        if (latestTime === prevPopulationTimeRef.current) return false;
+        const isFirstLoad = prevPopulationTimeRef.current === null;
+        setState({ status: 'success', data });
+        prevPopulationTimeRef.current = latestTime;
+        return !isFirstLoad;
+      } catch (err) {
+        if (cancelled) return false;
+        // 폴링 중 일시 실패는 직전 데이터 유지, 첫 load 실패만 error 노출
+        if (prevPopulationTimeRef.current === null) {
+          setState({ status: 'error' });
+        } else {
+          console.error('[useDestinationCongestion] 폴링 중 로드 실패:', err);
+        }
+        return false;
+      }
+    };
+
+    const tick = async () => {
+      if (cancelled) return;
+      const changed = await load();
+      if (cancelled) return;
+      timer = setTimeout(tick, changed ? FRESH_INTERVAL : RETRY_INTERVAL);
+    };
+
+    tick();
 
     return () => {
       cancelled = true;
+      if (timer) clearTimeout(timer);
     };
   }, [areaCode]);
 

--- a/src/hooks/useRanking.ts
+++ b/src/hooks/useRanking.ts
@@ -1,7 +1,11 @@
-import { useEffect, useReducer } from 'react';
-import axios from 'axios';
+import { useCallback, useEffect, useReducer, useRef } from 'react';
 import { fetchBusiestRanking, fetchRelaxedRanking } from '../api/congestionApi';
 import type { RankingEntry } from '../types/congestion';
+
+// 백엔드가 5분 주기로 갱신되므로 새 데이터 받은 직후엔 5분 동안 새 데이터 없음.
+// 같은 데이터 받은 경우(백엔드 갱신 직전 폴링)만 짧게 재시도해 다음 갱신을 따라잡는다.
+const FRESH_INTERVAL = 5 * 60 * 1000; // 5분
+const RETRY_INTERVAL = 60 * 1000; // 60초
 
 const RANKING_LIMIT = 122;
 
@@ -19,32 +23,60 @@ function rankingReducer(_: State, action: Action): State {
   }
 }
 
+// useCongestionMarkers와 동일한 adaptive 폴링으로 5분 갱신 주기와 동기화한다.
+// 첫 entry의 populationTime이 직전과 다르면 새 데이터로 보고 dispatch.
+// 첫 load는 백엔드 갱신 직후라는 보장이 없어 false 반환 → 60초 후 재시도로 위상 동기화.
 export const useRanking = (tab: 'busiest' | 'relaxed') => {
   const [state, dispatch] = useReducer(rankingReducer, {
     entries: [],
     loading: true,
     error: false,
   });
+  const prevPopulationTimeRef = useRef<string | null>(null);
+
+  const load = useCallback(async (): Promise<boolean> => {
+    try {
+      const loadData = tab === 'busiest' ? fetchBusiestRanking : fetchRelaxedRanking;
+      const data = await loadData(RANKING_LIMIT);
+      const latestTime = data.rankings[0]?.populationTime ?? null;
+      if (latestTime === null) return false;
+      if (latestTime === prevPopulationTimeRef.current) return false;
+      const isFirstLoad = prevPopulationTimeRef.current === null;
+      dispatch({ type: 'success', entries: data.rankings });
+      prevPopulationTimeRef.current = latestTime;
+      return !isFirstLoad;
+    } catch (err) {
+      // 폴링 중 일시 실패는 직전 데이터 유지, 첫 load 실패만 error 노출
+      if (prevPopulationTimeRef.current === null) {
+        dispatch({ type: 'error' });
+      } else {
+        console.error('[useRanking] 폴링 중 로드 실패:', err);
+      }
+      return false;
+    }
+  }, [tab]);
 
   useEffect(() => {
-    const controller = new AbortController();
+    // tab 전환 시 직전 시각과 비교되지 않도록 리셋
+    prevPopulationTimeRef.current = null;
     dispatch({ type: 'reset' });
-    const loadData = tab === 'busiest' ? fetchBusiestRanking : fetchRelaxedRanking;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let cancelled = false;
 
-    loadData(RANKING_LIMIT, controller.signal)
-      .then((data) => {
-        if (!controller.signal.aborted) {
-          dispatch({ type: 'success', entries: data.rankings });
-        }
-      })
-      .catch((err) => {
-        if (!axios.isCancel(err)) {
-          dispatch({ type: 'error' });
-        }
-      });
+    const tick = async () => {
+      if (cancelled) return;
+      const changed = await load();
+      if (cancelled) return;
+      timer = setTimeout(tick, changed ? FRESH_INTERVAL : RETRY_INTERVAL);
+    };
 
-    return () => controller.abort();
-  }, [tab]);
+    tick();
+
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [load]);
 
   return state;
 };

--- a/src/hooks/useRanking.ts
+++ b/src/hooks/useRanking.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useReducer, useRef } from 'react';
+import axios from 'axios';
 import { fetchBusiestRanking, fetchRelaxedRanking } from '../api/congestionApi';
 import type { RankingEntry } from '../types/congestion';
 
@@ -34,38 +35,44 @@ export const useRanking = (tab: 'busiest' | 'relaxed') => {
   });
   const prevPopulationTimeRef = useRef<string | null>(null);
 
-  const load = useCallback(async (): Promise<boolean> => {
-    try {
-      const loadData = tab === 'busiest' ? fetchBusiestRanking : fetchRelaxedRanking;
-      const data = await loadData(RANKING_LIMIT);
-      const latestTime = data.rankings[0]?.populationTime ?? null;
-      if (latestTime === null) return false;
-      if (latestTime === prevPopulationTimeRef.current) return false;
-      const isFirstLoad = prevPopulationTimeRef.current === null;
-      dispatch({ type: 'success', entries: data.rankings });
-      prevPopulationTimeRef.current = latestTime;
-      return !isFirstLoad;
-    } catch (err) {
-      // 폴링 중 일시 실패는 직전 데이터 유지, 첫 load 실패만 error 노출
-      if (prevPopulationTimeRef.current === null) {
-        dispatch({ type: 'error' });
-      } else {
-        console.error('[useRanking] 폴링 중 로드 실패:', err);
+  const load = useCallback(
+    async (signal: AbortSignal): Promise<boolean> => {
+      try {
+        const loadData = tab === 'busiest' ? fetchBusiestRanking : fetchRelaxedRanking;
+        const data = await loadData(RANKING_LIMIT, signal);
+        if (signal.aborted) return false;
+        const latestTime = data.rankings[0]?.populationTime ?? null;
+        if (latestTime === null) return false;
+        if (latestTime === prevPopulationTimeRef.current) return false;
+        const isFirstLoad = prevPopulationTimeRef.current === null;
+        dispatch({ type: 'success', entries: data.rankings });
+        prevPopulationTimeRef.current = latestTime;
+        return !isFirstLoad;
+      } catch (err) {
+        if (axios.isCancel(err) || signal.aborted) return false;
+        // 폴링 중 일시 실패는 직전 데이터 유지, 첫 load 실패만 error 노출
+        if (prevPopulationTimeRef.current === null) {
+          dispatch({ type: 'error' });
+        } else {
+          console.error('[useRanking] 폴링 중 로드 실패:', err);
+        }
+        return false;
       }
-      return false;
-    }
-  }, [tab]);
+    },
+    [tab],
+  );
 
   useEffect(() => {
     // tab 전환 시 직전 시각과 비교되지 않도록 리셋
     prevPopulationTimeRef.current = null;
     dispatch({ type: 'reset' });
+    const controller = new AbortController();
     let timer: ReturnType<typeof setTimeout> | null = null;
     let cancelled = false;
 
     const tick = async () => {
       if (cancelled) return;
-      const changed = await load();
+      const changed = await load(controller.signal);
       if (cancelled) return;
       timer = setTimeout(tick, changed ? FRESH_INTERVAL : RETRY_INTERVAL);
     };
@@ -74,6 +81,7 @@ export const useRanking = (tab: 'busiest' | 'relaxed') => {
 
     return () => {
       cancelled = true;
+      controller.abort();
       if (timer) clearTimeout(timer);
     };
   }, [load]);

--- a/src/hooks/useTopRankings.ts
+++ b/src/hooks/useTopRankings.ts
@@ -1,7 +1,12 @@
-import { useEffect, useReducer } from 'react';
+import { useCallback, useEffect, useReducer, useRef } from 'react';
 import axios from 'axios';
 import { fetchBusiestRanking, fetchRelaxedRanking } from '../api/congestionApi';
 import type { RankingEntry } from '../types/congestion';
+
+// 백엔드가 5분 주기로 갱신되므로 새 데이터 받은 직후엔 5분 동안 새 데이터 없음.
+// 같은 데이터 받은 경우(백엔드 갱신 직전 폴링)만 짧게 재시도해 다음 갱신을 따라잡는다.
+const FRESH_INTERVAL = 5 * 60 * 1000; // 5분
+const RETRY_INTERVAL = 60 * 1000; // 60초
 
 type State = {
   busiest: RankingEntry[];
@@ -30,6 +35,9 @@ function topRankingsReducer(state: State, action: Action): State {
 
 // busiest/relaxed 두 랭킹을 한 번에 가져와 미리보기 카드/시트에서 같이 쓰도록 만든 hook.
 // 단일 useRanking은 limit=122 고정이라 top N 미리보기 용도엔 부적합 — limit를 인자로 받는다.
+// useCongestionMarkers와 동일한 adaptive 폴링으로 5분 갱신 주기와 동기화한다.
+// 단일 endpoint인 useCongestionMarkers와 달리 busiest/relaxed 두 endpoint를 병렬로 호출하므로
+// 진행 중 요청을 즉시 끊기 위해 AbortController도 함께 사용한다.
 export const useTopRankings = (limit: number) => {
   const [state, dispatch] = useReducer(topRankingsReducer, {
     busiest: [],
@@ -37,29 +45,61 @@ export const useTopRankings = (limit: number) => {
     loading: true,
     error: false,
   });
+  const prevPopulationTimeRef = useRef<string | null>(null);
+
+  // busiest 첫 entry의 populationTime이 직전과 다르면 새 데이터로 보고 dispatch.
+  // 반환값으로 "백엔드 갱신 위상과 동기화됐는지"를 알려 호출자가 다음 폴링 주기를 결정한다.
+  // 첫 load는 백엔드 갱신 직후라는 보장이 없어 false 반환 → 60초 후 재시도로 위상 동기화.
+  const load = useCallback(
+    async (signal: AbortSignal): Promise<boolean> => {
+      try {
+        const [b, r] = await Promise.all([
+          fetchBusiestRanking(limit, signal),
+          fetchRelaxedRanking(limit, signal),
+        ]);
+        if (signal.aborted) return false;
+        const latestTime = b.rankings[0]?.populationTime ?? null;
+        if (latestTime === null) return false;
+        if (latestTime === prevPopulationTimeRef.current) return false;
+        const isFirstLoad = prevPopulationTimeRef.current === null;
+        dispatch({ type: 'success', busiest: b.rankings, relaxed: r.rankings });
+        prevPopulationTimeRef.current = latestTime;
+        return !isFirstLoad;
+      } catch (err) {
+        if (axios.isCancel(err) || signal.aborted) return false;
+        // 폴링 중 일시 실패는 직전 데이터 유지, 첫 load 실패만 error 노출
+        if (prevPopulationTimeRef.current === null) {
+          dispatch({ type: 'error' });
+        } else {
+          console.error('[useTopRankings] 폴링 중 로드 실패:', err);
+        }
+        return false;
+      }
+    },
+    [limit],
+  );
 
   useEffect(() => {
+    prevPopulationTimeRef.current = null;
     const controller = new AbortController();
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let cancelled = false;
 
-    Promise.all([
-      fetchBusiestRanking(limit, controller.signal),
-      fetchRelaxedRanking(limit, controller.signal),
-    ])
-      .then(([b, r]) => {
-        if (!controller.signal.aborted) {
-          dispatch({ type: 'success', busiest: b.rankings, relaxed: r.rankings });
-        }
-      })
-      .catch((err) => {
-        // abort 후 미세 타이밍에 CancelError가 아닌 형태로 reject되는 케이스(네트워크 race)
-        // 까지 차단해, 언마운트된 컴포넌트에 dispatch가 도달하지 않도록 함.
-        if (controller.signal.aborted) return;
-        if (axios.isCancel(err)) return;
-        dispatch({ type: 'error' });
-      });
+    const tick = async () => {
+      if (cancelled) return;
+      const changed = await load(controller.signal);
+      if (cancelled) return;
+      timer = setTimeout(tick, changed ? FRESH_INTERVAL : RETRY_INTERVAL);
+    };
 
-    return () => controller.abort();
-  }, [limit]);
+    tick();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+      if (timer) clearTimeout(timer);
+    };
+  }, [load]);
 
   return state;
 };

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,5 +1,4 @@
-import { useState, useCallback, useRef } from 'react';
-import axios from 'axios';
+import { useState, useCallback, useMemo } from 'react';
 import KakaoMap from '../components/map/KakaoMap';
 import Header from '../components/layout/Header';
 import CategoryFilter from '../components/filter/CategoryFilter';
@@ -8,9 +7,9 @@ import CongestionLegend from '../components/congestion/CongestionLegend';
 import CongestionRankCard from '../components/congestion/CongestionRankCard';
 import RankingBottomSheet from '../components/congestion/RankingBottomSheet';
 import AlternativeLocationBanner from '../components/map/AlternativeLocationBanner';
-import { fetchAlternativeLocations } from '../api/mapApi';
 import { useMapControls } from '../hooks/useMapControls';
 import { useTopRankings } from '../hooks/useTopRankings';
+import { useAlternativeLocations } from '../hooks/useAlternativeLocations';
 import { LOCATION_MAP } from '../data/locations';
 import type { AlternativeLocation } from '../types/map';
 import type { PlaceMarker } from '../types/congestion';
@@ -22,45 +21,41 @@ type AlternativeState = {
 
 const HomePage = () => {
   const [selectedCategory, setSelectedCategory] = useState('all');
-  const [alternativeState, setAlternativeState] = useState<AlternativeState>(null);
+  const [selectedSourceMarker, setSelectedSourceMarker] = useState<PlaceMarker | null>(null);
   const [searchFocus, setSearchFocus] = useState<{ areaCode: string; nonce: number } | null>(null);
-  const abortRef = useRef<AbortController | null>(null);
   const { setMap, zoomIn, zoomOut, locate, panTo, userLocation } = useMapControls();
   // top3 랭킹은 한 번만 fetch해서 데스크탑 카드 2개와 모바일 바텀시트가 같이 사용.
   // 각 컴포넌트가 자체 fetch하면 동일 endpoint를 4번 호출하게 됨.
   const rankings = useTopRankings(3);
+
+  // 마커 클릭 시점에 1회 fetch가 아니라 hook 안에서 폴링하도록 위임해, 사용자가 카드를
+  // 띄워둔 동안 백엔드 갱신(5분)을 따라잡는다. 응답 스키마에 시각 정보가 없어 hook 내부는
+  // adaptive가 아닌 5분 고정 폴링으로 fallback.
+  const altResult = useAlternativeLocations(selectedSourceMarker?.areaCode ?? null);
+
+  const alternativeState = useMemo<AlternativeState>(() => {
+    if (!selectedSourceMarker) return null;
+    if (altResult.status !== 'success') return null;
+    return { sourceMarker: selectedSourceMarker, locations: altResult.data };
+  }, [selectedSourceMarker, altResult]);
 
   const handleSearchSelect = useCallback(
     (areaCode: string) => {
       const loc = LOCATION_MAP.get(areaCode);
       if (loc) panTo(loc.latitude, loc.longitude);
       setSelectedCategory('all');
-      setAlternativeState(null);
+      setSelectedSourceMarker(null);
       setSearchFocus({ areaCode, nonce: Date.now() });
     },
     [panTo],
   );
 
-  const handleAlternativeRequest = useCallback(async (sourceMarker: PlaceMarker) => {
-    abortRef.current?.abort();
-    const controller = new AbortController();
-    abortRef.current = controller;
-
-    try {
-      const locations = await fetchAlternativeLocations(sourceMarker.areaCode, controller.signal);
-      if (locations.length > 0) {
-        setAlternativeState({ sourceMarker, locations });
-      } else {
-        setAlternativeState(null);
-      }
-    } catch (error: unknown) {
-      if (axios.isCancel(error)) return;
-      setAlternativeState(null);
-    }
+  const handleAlternativeRequest = useCallback((sourceMarker: PlaceMarker) => {
+    setSelectedSourceMarker(sourceMarker);
   }, []);
 
   const handleAlternativeClose = useCallback(() => {
-    setAlternativeState(null);
+    setSelectedSourceMarker(null);
   }, []);
 
   return (


### PR DESCRIPTION
## 관련 이슈
Closes #38 

백엔드 혼잡도 데이터는 5분마다 갱신되는데, 그 주기에 동기화되어 있는 hook은 useCongestionMarkers 하나뿐이었습니다.
이 훅은 응답 populationTime이 바뀌면 5분 뒤, 같으면 60초 뒤 재시도하는 adaptive 폴링을 입혀둔 hook이고, 나머지 혼잡도 hook들은 페이지 진입 시 1회만 fetch하고 끝이라 사용자가 그 페이지에 머무는 동안 데이터가 stale 상태로 남는 문제가 있었습니다.(HomePage에서 지도 마커는 5분마다 갱신되는데 옆 미리보기 카드는 5분 전 값이 그대로 떠 있는 식의 불일치)
이에 같은 정책을 나머지 hook들로 확장했습니다.

## 작업한 내용

- useTopRankings, useRanking, useDestinationCongestion은 응답에 populationTime이 있어서 useCongestionMarkers의 adaptive 패턴을 그대로 이식. FRESH 5분 / RETRY 60초, 첫 entry의 populationTime이 직전과 다르면 새 데이터로 보고 dispatch.

- useTopRankings는 단일 endpoint인 useCongestionMarkers와 달리 busiest/relaxed 두 endpoint를 병렬로 호출하기 때문에 cancelled 플래그만으로는 진행 중 요청을 끊지 못한다고 봐서, AbortController를 더해 cleanup에서 abort까지 호출.

- useRanking은 tab을 바꿀 때 ref와 state를 함께 리셋해 직전 tab 시각과 비교되지 않도록 처리. useDestinationCongestion은 areaCode가 null이 되면 idle로 돌아가면서 폴링 정지.

- useAlternativeLocations는 좀 다르게 처리. 응답(AlternativeLocation[])에 시각 정보가 없어서 changed 판정을 적용할 수 없으므로 adaptive 대신 5분 고정 폴링으로 fallback. 백엔드 응답에 populationTime을 추가하는 건 별도 이슈로 분리.

## HomePage 직접 호출 경로 통합

HomePage는 마커 추천 버튼을 누르면 fetchAlternativeLocations를 직접 호출하고 alternativeState로 결과를 들고 있던 별도 경로가 있어서, 같은 데이터인데 hook을 거치지 않아 위 정책이 자동으로 안 먹는 상태였음. selectedSourceMarker state만 유지하고 useAlternativeLocations에 그 areaCode를 넘기는 식으로 바꾸고, hook 결과와 sourceMarker를 useMemo로 묶어 기존 UI 분기 그대로 유지.

결과적으로 HomePage에서 axios와 abortRef가 빠지고, 마커 추천 버튼으로 띄운 banner도 hook의 5분 폴링을 그대로 따라감.

## 폴링 제외

useAiReport는 백엔드가 시간대(시) 단위로 새 리포트를 만들기 때문에 5분 폴링이 의미 없음. 사용자가 DetailPage에 머무는 동안 시간대 경계를 넘는 경우 별도 처리(시계 tick이나 1시간 폴링)가 필요한데 그건 후속 이슈로 분리.

useCultureEvents는 정적 데이터, useAddress는 좌표→주소라 변하지 않고, useTransitRoute는 사용자가 검색 버튼을 누른 시점에만 호출하는 의도된 패턴이라 폴링 대상이 아님.

## 검증

5분 단위라 그대로 두면 확인이 너무 오래 걸려서 interval을 잠깐 짧게 바꿔두고(FRESH 30초 / RETRY 10초 / POLL 30초) dev에서 페이지별로 자동 갱신되는지 Network 탭으로 확인한 뒤 원복. HomePage 미리보기 카드와 대체장소 banner, RankingPage, RoutePlanner 도착지, DetailPage 대체장소 다섯 군데 모두 의도된 주기로 폴링 도는 걸 확인.