### PR TITLE
refactor: useAiReport를 TanStack Query로 전환 — 캐시 + visibility 폴링 결합

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@posthog/react": "^1.10.0",
+        "@tanstack/react-query": "^5.101.0",
+        "@tanstack/react-query-devtools": "^5.101.0",
         "axios": "^1.13.6",
         "lucide-react": "^1.7.0",
         "posthog-js": "^1.380.1",
@@ -1719,6 +1721,59 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.0.tgz",
+      "integrity": "sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.101.0.tgz",
+      "integrity": "sha512-MVqw17k08RQtGGLEL654+dX/btbX9p/8WjkznO//zusLTMaObxi3Q+MoFwGVkC9K3tqjn8qrrNhJevXx4fJTeQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.0.tgz",
+      "integrity": "sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.101.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.101.0.tgz",
+      "integrity": "sha512-cpZA0+WqKXwrwMfiWZEGGF6QrIWVQFbhBtxqDF5sQsAfrFf47HIE6fiPbQU3wyAUEN2+7UNqLCQe7oG6m3f93w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.101.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.101.0",
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
   "dependencies": {
     "@phosphor-icons/react": "^2.1.10",
     "@posthog/react": "^1.10.0",
+    "@tanstack/react-query": "^5.101.0",
+    "@tanstack/react-query-devtools": "^5.101.0",
     "axios": "^1.13.6",
     "lucide-react": "^1.7.0",
     "posthog-js": "^1.380.1",

--- a/src/hooks/useAiReport.ts
+++ b/src/hooks/useAiReport.ts
@@ -50,6 +50,16 @@ const getSeoulHour = (): number => {
   }
 };
 
+// 모듈 스코프로 추출해 select 함수 참조를 렌더 간 안정화한다.
+// 인라인으로 두면 매 렌더마다 새 함수 참조가 생겨 structural sharing이 작동하지 않고,
+// 같은 응답에도 새 객체를 반환해 메모이제이션 효과를 잃는다.
+const selectReport = (data: AireportResponse): Selected => {
+  const reportHour = parseHour(data.populationTime);
+  if (reportHour == null) return { kind: 'success', data };
+  const diff = circularHourDiff(reportHour, getSeoulHour());
+  return diff > HOUR_TOLERANCE ? { kind: 'stale' } : { kind: 'success', data };
+};
+
 export const useAiReport = (areaCode: string | null): State => {
   const query = useQuery<AireportResponse, Error, Selected>({
     queryKey: ['ai-report', areaCode],
@@ -65,15 +75,16 @@ export const useAiReport = (areaCode: string | null): State => {
       if (axios.isAxiosError(err) && err.response?.status === 404) return false;
       return count < 1;
     },
-    select: (data) => {
-      const reportHour = parseHour(data.populationTime);
-      if (reportHour == null) return { kind: 'success', data };
-      const diff = circularHourDiff(reportHour, getSeoulHour());
-      return diff > HOUR_TOLERANCE ? { kind: 'stale' } : { kind: 'success', data };
-    },
+    select: selectReport,
   });
 
   if (!areaCode) return { status: 'loading' };
+  // SWR 정합: 캐시된 데이터가 있으면 우선 표시. 배경 refetch가 일시적으로 실패해도
+  // 직전에 성공한 결과를 유지하고, error/empty 분기는 처음부터 데이터가 없을 때만 적용.
+  if (query.data) {
+    if (query.data.kind === 'stale') return { status: 'stale' };
+    return { status: 'success', data: query.data.data };
+  }
   if (query.isError) {
     const err = query.error;
     if (axios.isAxiosError(err) && err.response?.status === 404) {
@@ -81,7 +92,5 @@ export const useAiReport = (areaCode: string | null): State => {
     }
     return { status: 'error' };
   }
-  if (query.isPending) return { status: 'loading' };
-  if (query.data.kind === 'stale') return { status: 'stale' };
-  return { status: 'success', data: query.data.data };
+  return { status: 'loading' };
 };

--- a/src/hooks/useAiReport.ts
+++ b/src/hooks/useAiReport.ts
@@ -1,7 +1,11 @@
-import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import { fetchAiReport } from '../api/congestionApi';
 import type { AireportResponse } from '../types/congestion';
+
+type Selected =
+  | { kind: 'success'; data: AireportResponse }
+  | { kind: 'stale' };
 
 type State =
   | { status: 'loading' }
@@ -12,6 +16,12 @@ type State =
 
 // 분석이 현재 시간대와 어긋나면 보여주지 않기 위한 허용 폭 (±N시간)
 const HOUR_TOLERANCE = 3;
+
+// 백엔드 AI 리포트는 혼잡도 변화 이벤트 기반으로 생성되어 fixed 갱신 주기가 없고
+// Redis TTL이 3시간. 짧은 재방문은 캐시 hit, 장시간 체류는 visibility 기반 polling,
+// 탭 복귀는 refetchOnWindowFocus로 한 번에 커버한다.
+const STALE_TIME = 5 * 60 * 1000; // 5분
+const REFETCH_INTERVAL = 5 * 60 * 1000; // 5분
 
 // "2026-05-24 12:30" → 12
 const parseHour = (populationTime: string): number | null => {
@@ -40,41 +50,38 @@ const getSeoulHour = (): number => {
   }
 };
 
-export const useAiReport = (areaCode: string | null) => {
-  const [state, setState] = useState<State>({ status: 'loading' });
+export const useAiReport = (areaCode: string | null): State => {
+  const query = useQuery<AireportResponse, Error, Selected>({
+    queryKey: ['ai-report', areaCode],
+    queryFn: ({ signal }) => fetchAiReport(areaCode!, signal),
+    enabled: !!areaCode,
+    staleTime: STALE_TIME,
+    refetchInterval: REFETCH_INTERVAL,
+    // 다른 탭이 활성화된 동안엔 polling 차단 — 사용자가 보지 않는 페이지로 트래픽 낭비 X
+    refetchIntervalInBackground: false,
+    refetchOnWindowFocus: true,
+    retry: (count, err) => {
+      // 404는 비즈니스적 'empty'라 재시도 X
+      if (axios.isAxiosError(err) && err.response?.status === 404) return false;
+      return count < 1;
+    },
+    select: (data) => {
+      const reportHour = parseHour(data.populationTime);
+      if (reportHour == null) return { kind: 'success', data };
+      const diff = circularHourDiff(reportHour, getSeoulHour());
+      return diff > HOUR_TOLERANCE ? { kind: 'stale' } : { kind: 'success', data };
+    },
+  });
 
-  useEffect(() => {
-    if (!areaCode) return;
-
-    // 다른 장소로 이동했을 때 이전 분석이 잠깐 노출되는 stale 표시 방지
-    // (콜백 안 setState만 룰 적용 대상이라, 동기 reset 한 줄은 명시적으로 허용)
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setState({ status: 'loading' });
-
-    const controller = new AbortController();
-
-    fetchAiReport(areaCode, controller.signal)
-      .then((data) => {
-        if (controller.signal.aborted) return;
-        const reportHour = parseHour(data.populationTime);
-        if (reportHour == null) {
-          setState({ status: 'success', data });
-          return;
-        }
-        const diff = circularHourDiff(reportHour, getSeoulHour());
-        setState(diff > HOUR_TOLERANCE ? { status: 'stale' } : { status: 'success', data });
-      })
-      .catch((err) => {
-        if (axios.isCancel(err)) return;
-        setState(
-          axios.isAxiosError(err) && err.response?.status === 404
-            ? { status: 'empty' }
-            : { status: 'error' },
-        );
-      });
-
-    return () => controller.abort();
-  }, [areaCode]);
-
-  return state;
+  if (!areaCode) return { status: 'loading' };
+  if (query.isError) {
+    const err = query.error;
+    if (axios.isAxiosError(err) && err.response?.status === 404) {
+      return { status: 'empty' };
+    }
+    return { status: 'error' };
+  }
+  if (query.isPending) return { status: 'loading' };
+  if (query.data.kind === 'stale') return { status: 'stale' };
+  return { status: 'success', data: query.data.data };
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,8 @@ import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import posthog from 'posthog-js';
 import { PostHogProvider } from '@posthog/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import './index.css';
 import App from './App.tsx';
 
@@ -16,12 +18,28 @@ if (posthogToken && posthogHost) {
   });
 }
 
+// hook마다 갱신 정책이 달라(adaptive polling, 정적 캐싱, 시간대 단위 등)
+// default는 보수적으로 두고 각 useQuery에서 staleTime·refetchInterval·focus 정책을 명시한다.
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 0,
+      gcTime: 5 * 60 * 1000,
+      retry: 1,
+      refetchOnWindowFocus: true,
+    },
+  },
+});
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <PostHogProvider client={posthog}>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+        {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
+      </QueryClientProvider>
     </PostHogProvider>
   </StrictMode>,
 );


### PR DESCRIPTION
## 관려 이슈
Closes #59 

## 배경

DetailPage(`/place/:areaCode`)에서 장소별 혼잡 원인을 풀어주는 **AI 리포트**가 사용자가 페이지에 들어갈 때 한 번만 표시되고, 그 후에는 페이지를 떠나기 전까지 다시 받아오지 않음. 결과적으로 사용자가 그 화면을 띄워둔 채로 다른 작업을 하는 동안 백엔드에서 새 리포트가 만들어져도 클라이언트는 모르는 상태. 같은 마커로 다시 들어왔을 때도 캐시가 없어서 매번 동일한 호출이 발생.

## 백엔드 갱신 패턴

AI 리포트는 혼잡도 변화 시점에 이벤트로 생성되어 Redis에 3시간 TTL로 저장됨. 정해진 주기가 없기 때문에 "5분마다 폴링" 같은 단순 정책은 새 데이터가 언제 올지 모르는 채로 호출만 늘리고, 페이지 진입 시 1회 fetch만 하는 기존 방식은 장시간 체류 시나리오를 못 커버.

## 검토한 옵션

- fixed-interval polling — 갱신 시점 예측 불가로 ROI 낮음
- refetchOnWindowFocus만 사용 — 탭 전환 외 시나리오(창 띄워두기) 미커버
- 시계 tick 기반 시간대 경계 refetch — 백엔드가 시간대 단위 생성이 아니라 의미 약함
- SSE 도입 — 백엔드 변경 필요

백엔드 변경 없이 짧은 재방문·장시간 체류·탭 복귀를 한 번에 다루기 위해 TanStack Query 도입.

## 도입 설정

- staleTime 5분 — 짧은 재방문은 캐시 hit
- refetchInterval 5분 + refetchIntervalInBackground false — 페이지가 보일 때만 자동 새로고침
- refetchOnWindowFocus true — 탭 복귀 시 즉시 refetch
- retry는 404 제외 (404는 empty 비즈니스 상태)
- select에 기존 KST hour tolerance 분기를 이식해 stale 분기 유지

동일 응답이면 TanStack의 structural sharing으로 re-render 차단되어 깜빡임 없고, 백그라운드 탭에서는 폴링이 멈춰 트래픽도 절감. DetailPage가 받는 5가지 status(loading/success/empty/stale/error) 동작은 변경 없음.

## 범위 제외

이전 PR #55(adaptive 폴링 도입)와 #61(폴링 정책 확장)에서 다룬 혼잡도 hook들 — useCongestionMarkers·useTopRankings·useRanking·useDestinationCongestion — 은 fetcher가 응답 시각을 비교해서 다음 폴링 간격을 직접 정하는 adaptive 정책이 박혀 있어 TanStack의 refetchInterval 모델로는 같은 정책을 표현할 수 없음. 본 PR은 정적 hook 중 useAiReport만 시범 적용하고, useCultureEvents·useAddress 같은 다른 정적 hook 확장은 후속 이슈로 분리.
