### PR TITLE
feat: DetailPage에 시간대·요일별 혼잡도 추이 그래프 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-kakao-maps-sdk": "^1.2.1",
-        "react-router-dom": "^7.13.1"
+        "react-router-dom": "^7.13.1",
+        "recharts": "^3.8.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -1094,6 +1095,42 @@
       "integrity": "sha512-GaeyU1vPxwZvYlSWdpxbLCRPqY2WKUZYUNjBlJHAlaAXbMmCfLgB2cvkwjidr8lhX8nyxINjjvQMiOSSfSSxcg==",
       "license": "MIT"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -1450,6 +1487,18 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.2",
@@ -1821,6 +1870,69 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1871,6 +1983,12 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.57.0",
@@ -2394,6 +2512,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2486,6 +2613,127 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2503,6 +2751,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -2618,6 +2872,16 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.0.tgz",
+      "integrity": "sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -2883,6 +3147,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -3208,6 +3478,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -3233,6 +3513,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-extglob": {
@@ -4048,6 +4337,13 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-kakao-maps-sdk": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/react-kakao-maps-sdk/-/react-kakao-maps-sdk-1.2.1.tgz",
@@ -4061,6 +4357,29 @@
         "kakao.maps.d.ts": "^0.1.40",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-refresh": {
@@ -4110,6 +4429,57 @@
         "react": ">=18",
         "react-dom": ">=18"
       }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -4268,6 +4638,12 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -4404,6 +4780,28 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-kakao-maps-sdk": "^1.2.1",
-    "react-router-dom": "^7.13.1"
+    "react-router-dom": "^7.13.1",
+    "recharts": "^3.8.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/src/api/congestionApi.ts
+++ b/src/api/congestionApi.ts
@@ -4,6 +4,7 @@ import type {
   AireportResponse,
   CongestionData,
   CongestionRankingResponse,
+  CongestionTrendResponse,
 } from '../types/congestion';
 
 export const fetchAllCongestion = async (): Promise<CongestionData[]> => {
@@ -45,6 +46,30 @@ export const fetchAiReport = async (
   const res = await instance.get<ApiResponse<AireportResponse>>(
     `/api/congestion/${areaCode}/ai-report`,
     { signal },
+  );
+  return res.data.data;
+};
+
+export const fetchHourlyTrend = async (
+  areaCode: string,
+  days = 7,
+  signal?: AbortSignal,
+): Promise<CongestionTrendResponse> => {
+  const res = await instance.get<ApiResponse<CongestionTrendResponse>>(
+    `/api/congestion/analysis/hourly/${areaCode}`,
+    { params: { days }, signal },
+  );
+  return res.data.data;
+};
+
+export const fetchDailyTrend = async (
+  areaCode: string,
+  days = 7,
+  signal?: AbortSignal,
+): Promise<CongestionTrendResponse> => {
+  const res = await instance.get<ApiResponse<CongestionTrendResponse>>(
+    `/api/congestion/analysis/daily/${areaCode}`,
+    { params: { days }, signal },
   );
   return res.data.data;
 };

--- a/src/components/congestion/CongestionTrendChart.tsx
+++ b/src/components/congestion/CongestionTrendChart.tsx
@@ -1,0 +1,172 @@
+import { useMemo } from 'react';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import {
+  CONGESTION_LEVEL_MAP,
+  CONGESTION_COLORS,
+  CONGESTION_COLOR_UNKNOWN,
+} from '../../types/congestion';
+import type {
+  CongestionTrendKind,
+  CongestionTrendPoint,
+} from '../../types/congestion';
+
+interface Props {
+  data: CongestionTrendPoint[];
+  kind: CongestionTrendKind;
+  highlightKey?: number | null;
+}
+
+// 백엔드는 일요일=1, 토요일=7로 응답하는데 한국 사용자에게 자연스러운 월부터 일 순서로 정렬.
+// 평일이 왼쪽, 주말이 오른쪽 끝에 모여 "주말이 붐비는지" 같은 패턴을 한눈에 보이게 한다.
+const DAY_ORDER: Record<number, number> = {
+  2: 0, // 월
+  3: 1, // 화
+  4: 2, // 수
+  5: 3, // 목
+  6: 4, // 금
+  7: 5, // 토
+  1: 6, // 일
+};
+
+const getColor = (congestionLevel: string): string => {
+  const mapped = CONGESTION_LEVEL_MAP[congestionLevel];
+  return mapped ? CONGESTION_COLORS[mapped] : CONGESTION_COLOR_UNKNOWN;
+};
+
+interface TooltipPayloadItem {
+  payload: CongestionTrendPoint;
+}
+
+interface CustomTooltipProps {
+  active?: boolean;
+  payload?: TooltipPayloadItem[];
+}
+
+const CustomTooltip = ({ active, payload }: CustomTooltipProps) => {
+  if (!active || !payload || payload.length === 0) return null;
+  const point = payload[0].payload;
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg shadow-md px-3 py-2 text-sm">
+      <div className="font-semibold text-gray-900 mb-1">{point.label}</div>
+      <div className="text-gray-700 flex items-center gap-1.5">
+        <span
+          className="inline-block w-2.5 h-2.5 rounded-full"
+          style={{ backgroundColor: getColor(point.congestionLevel) }}
+          aria-hidden
+        />
+        {point.congestionLevel}
+      </div>
+      <div className="text-gray-500 text-xs mt-0.5">
+        평균 {Math.round(point.avgMinPeople)} ~ {Math.round(point.avgMaxPeople)}명
+      </div>
+    </div>
+  );
+};
+
+// 현재 시각/요일 막대 위에 "지금" 라벨과 작은 dot을 띄워 검은 stroke 없이 강조.
+// recharts label content로 막대마다 호출되며, 현재 키와 일치할 때만 렌더.
+const renderNowMarker = (highlightKey: number | null) => (props: unknown) => {
+  if (highlightKey === null) return null;
+  const p = props as {
+    x?: number | string;
+    y?: number | string;
+    width?: number | string;
+    value?: number;
+  };
+  if (
+    p.value === undefined ||
+    p.value !== highlightKey ||
+    p.x === undefined ||
+    p.y === undefined ||
+    p.width === undefined
+  ) {
+    return null;
+  }
+  const numX = Number(p.x);
+  const numY = Number(p.y);
+  const numWidth = Number(p.width);
+  const cx = numX + numWidth / 2;
+  return (
+    <g>
+      <text
+        x={cx}
+        y={numY - 18}
+        textAnchor="middle"
+        fontSize={11}
+        fontWeight={600}
+        fill="#1f2937"
+      >
+        지금
+      </text>
+      <circle cx={cx} cy={numY - 8} r={3} fill="#1f2937" />
+    </g>
+  );
+};
+
+const CongestionTrendChart = ({ data, kind, highlightKey = null }: Props) => {
+  const orderedData = useMemo(() => {
+    if (kind !== 'daily') return data;
+    return [...data].sort((a, b) => {
+      const orderA = DAY_ORDER[a.key] ?? Infinity;
+      const orderB = DAY_ORDER[b.key] ?? Infinity;
+      return orderA - orderB;
+    });
+  }, [data, kind]);
+
+  // 데이터 객체에 fill·fillOpacity를 포함하면 Bar가 자동으로 각 막대에 적용한다.
+  // Recharts 3.x에서 children Cell이 deprecated되어 이 방식이 권장 패턴.
+  const styledData = useMemo(
+    () =>
+      orderedData.map((point) => ({
+        ...point,
+        fill: getColor(point.congestionLevel),
+        fillOpacity:
+          highlightKey === null ? 1 : point.key === highlightKey ? 1 : 0.5,
+      })),
+    [orderedData, highlightKey],
+  );
+
+  return (
+    <div
+      className="w-full h-64"
+      role="img"
+      aria-label={
+        kind === 'hourly'
+          ? '시간대별 평균 혼잡도 막대 차트'
+          : '요일별 평균 혼잡도 막대 차트'
+      }
+    >
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={styledData} margin={{ top: 28, right: 12, left: 0, bottom: 8 }}>
+          <XAxis
+            dataKey="label"
+            tick={{ fontSize: 12, fill: '#6b7280' }}
+            tickLine={false}
+            axisLine={{ stroke: '#e5e7eb' }}
+          />
+          <YAxis
+            tick={{ fontSize: 12, fill: '#6b7280' }}
+            tickLine={false}
+            axisLine={{ stroke: '#e5e7eb' }}
+            width={40}
+          />
+          <Tooltip content={<CustomTooltip />} cursor={false} />
+          <Bar
+            dataKey="avgMaxPeople"
+            radius={[4, 4, 0, 0]}
+            label={renderNowMarker(highlightKey)}
+          />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+export default CongestionTrendChart;

--- a/src/components/congestion/CongestionTrendChart.tsx
+++ b/src/components/congestion/CongestionTrendChart.tsx
@@ -70,19 +70,50 @@ const CustomTooltip = ({ active, payload }: CustomTooltipProps) => {
   );
 };
 
+// Recharts 3.x에서 Cell이 deprecated되어 v4에서 제거 예정. 공식 권장 패턴인 shape
+// prop으로 막대마다 색상·불투명도·둥근 모서리를 직접 그려 v4 호환을 확보한다.
+const renderBarShape =
+  (highlightKey: number | null) =>
+  (props: unknown) => {
+    const p = props as {
+      x?: number;
+      y?: number;
+      width?: number;
+      height?: number;
+      payload?: CongestionTrendPoint;
+    };
+    if (
+      p.x === undefined ||
+      p.y === undefined ||
+      p.width === undefined ||
+      p.height === undefined ||
+      !p.payload
+    ) {
+      return <g />;
+    }
+    const fill = getColor(p.payload.congestionLevel);
+    const fillOpacity =
+      highlightKey === null ? 1 : p.payload.key === highlightKey ? 1 : 0.5;
+    // 위쪽 모서리만 둥글게(radius 4). height가 작은 경우 모서리 반경 보정.
+    const r = Math.max(0, Math.min(4, p.height, p.width / 2));
+    const path = `M ${p.x},${p.y + r} Q ${p.x},${p.y} ${p.x + r},${p.y} L ${p.x + p.width - r},${p.y} Q ${p.x + p.width},${p.y} ${p.x + p.width},${p.y + r} L ${p.x + p.width},${p.y + p.height} L ${p.x},${p.y + p.height} Z`;
+    return <path d={path} fill={fill} fillOpacity={fillOpacity} />;
+  };
+
 // 현재 시각/요일 막대 위에 "지금" 라벨과 작은 dot을 띄워 검은 stroke 없이 강조.
-// recharts label content로 막대마다 호출되며, 현재 키와 일치할 때만 렌더.
+// recharts label content로 막대마다 호출되며, 데이터 포인트의 key와 일치할 때만 렌더.
+// (Bar의 dataKey 값인 avgMaxPeople이 아니라 payload.key를 비교해야 정확)
 const renderNowMarker = (highlightKey: number | null) => (props: unknown) => {
   if (highlightKey === null) return null;
   const p = props as {
     x?: number | string;
     y?: number | string;
     width?: number | string;
-    value?: number;
+    payload?: { key?: number };
   };
   if (
-    p.value === undefined ||
-    p.value !== highlightKey ||
+    p.payload?.key === undefined ||
+    p.payload.key !== highlightKey ||
     p.x === undefined ||
     p.y === undefined ||
     p.width === undefined
@@ -120,18 +151,6 @@ const CongestionTrendChart = ({ data, kind, highlightKey = null }: Props) => {
     });
   }, [data, kind]);
 
-  // 데이터 객체에 fill·fillOpacity를 포함하면 Bar가 자동으로 각 막대에 적용한다.
-  // Recharts 3.x에서 children Cell이 deprecated되어 이 방식이 권장 패턴.
-  const styledData = useMemo(
-    () =>
-      orderedData.map((point) => ({
-        ...point,
-        fill: getColor(point.congestionLevel),
-        fillOpacity:
-          highlightKey === null ? 1 : point.key === highlightKey ? 1 : 0.5,
-      })),
-    [orderedData, highlightKey],
-  );
 
   return (
     <div
@@ -144,7 +163,7 @@ const CongestionTrendChart = ({ data, kind, highlightKey = null }: Props) => {
       }
     >
       <ResponsiveContainer width="100%" height="100%">
-        <BarChart data={styledData} margin={{ top: 28, right: 12, left: 0, bottom: 8 }}>
+        <BarChart data={orderedData} margin={{ top: 28, right: 12, left: 0, bottom: 8 }}>
           <XAxis
             dataKey="label"
             tick={{ fontSize: 12, fill: '#6b7280' }}
@@ -160,7 +179,7 @@ const CongestionTrendChart = ({ data, kind, highlightKey = null }: Props) => {
           <Tooltip content={<CustomTooltip />} cursor={false} />
           <Bar
             dataKey="avgMaxPeople"
-            radius={[4, 4, 0, 0]}
+            shape={renderBarShape(highlightKey)}
             label={renderNowMarker(highlightKey)}
           />
         </BarChart>

--- a/src/components/detail/CongestionTrendSection.tsx
+++ b/src/components/detail/CongestionTrendSection.tsx
@@ -7,43 +7,18 @@ interface Props {
   areaCode: string;
 }
 
-// 백엔드의 DAYOFWEEK는 1=일, 7=토. JavaScript toLocaleString('en-US', weekday:'short')의
-// 영문 약어를 매핑해 KST 기준 현재 요일 key를 얻는다.
-const DAY_SHORT_TO_KEY: Record<string, number> = {
-  Sun: 1,
-  Mon: 2,
-  Tue: 3,
-  Wed: 4,
-  Thu: 5,
-  Fri: 6,
-  Sat: 7,
-};
+// KST는 UTC+9 고정(DST 없음)이라 timestamp에 직접 offset을 더해 Date 객체를 만들고
+// getUTC* 메서드로 시간/요일을 읽는다. Intl/toLocaleString의 환경 의존 포맷(예:
+// 자정을 '24'로 반환, 요일이 'Sun.'처럼 마침표 포함) 문제를 피하는 안전한 방식.
+const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
 
-const getSeoulHour = (): number => {
-  try {
-    return Number(
-      new Intl.DateTimeFormat('en-US', {
-        timeZone: 'Asia/Seoul',
-        hour: 'numeric',
-        hour12: false,
-      }).format(new Date()),
-    );
-  } catch {
-    return new Date().getHours();
-  }
-};
+const kstNow = (): Date => new Date(Date.now() + KST_OFFSET_MS);
 
-const getSeoulDayOfWeekKey = (): number => {
-  try {
-    const short = new Date().toLocaleString('en-US', {
-      timeZone: 'Asia/Seoul',
-      weekday: 'short',
-    });
-    return DAY_SHORT_TO_KEY[short] ?? 1;
-  } catch {
-    return new Date().getDay() + 1;
-  }
-};
+const getSeoulHour = (): number => kstNow().getUTCHours();
+
+// JavaScript getUTCDay(): 0=일, 1=월, ..., 6=토
+// 백엔드 DAYOFWEEK: 1=일, 2=월, ..., 7=토 → +1 매핑
+const getSeoulDayOfWeekKey = (): number => kstNow().getUTCDay() + 1;
 
 const TICK_INTERVAL = 60 * 1000; // 1분
 

--- a/src/components/detail/CongestionTrendSection.tsx
+++ b/src/components/detail/CongestionTrendSection.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useHourlyTrend, useDailyTrend } from '../../hooks/useCongestionTrend';
+import CongestionTrendChart from '../congestion/CongestionTrendChart';
+import type { CongestionTrendKind } from '../../types/congestion';
+
+interface Props {
+  areaCode: string;
+}
+
+// 백엔드의 DAYOFWEEK는 1=일, 7=토. JavaScript toLocaleString('en-US', weekday:'short')의
+// 영문 약어를 매핑해 KST 기준 현재 요일 key를 얻는다.
+const DAY_SHORT_TO_KEY: Record<string, number> = {
+  Sun: 1,
+  Mon: 2,
+  Tue: 3,
+  Wed: 4,
+  Thu: 5,
+  Fri: 6,
+  Sat: 7,
+};
+
+const getSeoulHour = (): number => {
+  try {
+    return Number(
+      new Intl.DateTimeFormat('en-US', {
+        timeZone: 'Asia/Seoul',
+        hour: 'numeric',
+        hour12: false,
+      }).format(new Date()),
+    );
+  } catch {
+    return new Date().getHours();
+  }
+};
+
+const getSeoulDayOfWeekKey = (): number => {
+  try {
+    const short = new Date().toLocaleString('en-US', {
+      timeZone: 'Asia/Seoul',
+      weekday: 'short',
+    });
+    return DAY_SHORT_TO_KEY[short] ?? 1;
+  } catch {
+    return new Date().getDay() + 1;
+  }
+};
+
+const TICK_INTERVAL = 60 * 1000; // 1분
+
+const CongestionTrendSection = ({ areaCode }: Props) => {
+  const [kind, setKind] = useState<CongestionTrendKind>('hourly');
+
+  // 두 hook 모두 호출해 양쪽 캐시를 채워둔다. 응답이 작아 트래픽 부담은 낮고,
+  // 토글 전환 시 즉시 캐시 hit으로 표시가 가능해 UX 우선.
+  const hourlyQuery = useHourlyTrend(areaCode);
+  const dailyQuery = useDailyTrend(areaCode);
+  const currentQuery = kind === 'hourly' ? hourlyQuery : dailyQuery;
+
+  // 사용자가 페이지에 머무는 동안 시간이 흘러도 "지금" 강조가 따라가도록
+  // 1분 단위 tick으로 highlightKey를 재계산한다.
+  const [tick, setTick] = useState(0);
+  useEffect(() => {
+    const id = window.setInterval(() => setTick((t) => t + 1), TICK_INTERVAL);
+    return () => window.clearInterval(id);
+  }, []);
+
+  // tick은 본문에서 직접 참조하지 않지만, 1분 단위로 시간 흐름에 따라
+  // highlightKey를 강제 재계산하기 위한 의존성으로 의도적으로 포함한다.
+  const highlightKey = useMemo(
+    () => (kind === 'hourly' ? getSeoulHour() : getSeoulDayOfWeekKey()),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [kind, tick],
+  );
+
+  return (
+    <section className="bg-white rounded-2xl p-6 shadow-sm">
+      <div className="flex items-center justify-between mb-4">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-900">평소 혼잡도 추이</h2>
+          <p className="text-xs text-slate-500 mt-0.5">최근 7일 측정 데이터 평균</p>
+        </div>
+        <div className="flex gap-1 bg-slate-100 rounded-lg p-1">
+          <button
+            type="button"
+            onClick={() => setKind('hourly')}
+            className={`px-3 py-1 rounded-md text-sm transition-colors cursor-pointer ${
+              kind === 'hourly'
+                ? 'bg-white text-slate-900 shadow-sm font-semibold'
+                : 'text-slate-500 hover:text-slate-900'
+            }`}
+            aria-pressed={kind === 'hourly'}
+          >
+            시간대
+          </button>
+          <button
+            type="button"
+            onClick={() => setKind('daily')}
+            className={`px-3 py-1 rounded-md text-sm transition-colors cursor-pointer ${
+              kind === 'daily'
+                ? 'bg-white text-slate-900 shadow-sm font-semibold'
+                : 'text-slate-500 hover:text-slate-900'
+            }`}
+            aria-pressed={kind === 'daily'}
+          >
+            요일별
+          </button>
+        </div>
+      </div>
+
+      {currentQuery.isPending && (
+        <div className="h-64 animate-pulse bg-slate-50 rounded-xl" />
+      )}
+      {currentQuery.isError && (
+        <div className="h-64 flex items-center justify-center text-slate-400 text-sm">
+          추이 데이터를 불러올 수 없어요.
+        </div>
+      )}
+      {currentQuery.data && currentQuery.data.length === 0 && (
+        <div className="h-64 flex items-center justify-center text-slate-400 text-sm">
+          아직 충분한 데이터가 쌓이지 않았어요.
+        </div>
+      )}
+      {currentQuery.data && currentQuery.data.length > 0 && (
+        <CongestionTrendChart
+          data={currentQuery.data}
+          kind={kind}
+          highlightKey={highlightKey}
+        />
+      )}
+    </section>
+  );
+};
+
+export default CongestionTrendSection;

--- a/src/hooks/useCongestionTrend.ts
+++ b/src/hooks/useCongestionTrend.ts
@@ -1,0 +1,60 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
+import { fetchHourlyTrend, fetchDailyTrend } from '../api/congestionApi';
+import type {
+  CongestionTrendKind,
+  CongestionTrendPoint,
+  CongestionTrendResponse,
+} from '../types/congestion';
+
+// 백엔드 응답이 지난 N일 평균이라 같은 날 안에는 새 fetch가 평균에 거의 영향이 없고,
+// 의미 있는 갱신은 자정이 지나 7일 윈도가 한 칸 밀릴 때 발생.
+// queryKey에 KST 기준 오늘 날짜를 포함해 자정 경계에서 자동 새 fetch가 트리거되게 한다.
+const STALE_TIME = 24 * 60 * 60 * 1000;
+const GC_TIME = 24 * 60 * 60 * 1000;
+
+// 모듈 스코프로 추출해 select 함수 참조를 렌더 간 안정화 (structural sharing 보존).
+const selectData = (response: CongestionTrendResponse): CongestionTrendPoint[] => response.data;
+
+const getTodayKst = (): string => {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Asia/Seoul',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(new Date());
+};
+
+const useCongestionTrend = (
+  kind: CongestionTrendKind,
+  areaCode: string | null,
+  days = 7,
+) => {
+  // mount 시점의 KST 날짜를 잡아둔다. 사용자가 페이지에 머무는 동안 자정을 넘는
+  // 시나리오는 드물어 mount 기준 1회 계산으로 충분하다고 보고, 단순화.
+  const todayKst = useMemo(() => getTodayKst(), []);
+
+  return useQuery<CongestionTrendResponse, Error, CongestionTrendPoint[]>({
+    queryKey: ['congestion-trend', kind, areaCode, days, todayKst],
+    queryFn: ({ signal }) =>
+      kind === 'hourly'
+        ? fetchHourlyTrend(areaCode!, days, signal)
+        : fetchDailyTrend(areaCode!, days, signal),
+    enabled: !!areaCode,
+    staleTime: STALE_TIME,
+    gcTime: GC_TIME,
+    retry: (count, err) => {
+      // 404는 비즈니스적 'empty'라 재시도 X
+      if (axios.isAxiosError(err) && err.response?.status === 404) return false;
+      return count < 1;
+    },
+    select: selectData,
+  });
+};
+
+export const useHourlyTrend = (areaCode: string | null, days = 7) =>
+  useCongestionTrend('hourly', areaCode, days);
+
+export const useDailyTrend = (areaCode: string | null, days = 7) =>
+  useCongestionTrend('daily', areaCode, days);

--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -7,6 +7,7 @@ import AiInsightCard from '../components/detail/AiInsightCard';
 import CultureEventsSection from '../components/detail/CultureEventsSection';
 import LocationSection from '../components/detail/LocationSection';
 import AlternativePlacesSidebar from '../components/detail/AlternativePlacesSidebar';
+import CongestionTrendSection from '../components/detail/CongestionTrendSection';
 import { fetchCongestionByAreaCode } from '../api/congestionApi';
 import { LOCATION_MAP } from '../data/locations';
 import { CONGESTION_COLORS, CONGESTION_LEVEL_MAP } from '../types/congestion';
@@ -85,6 +86,8 @@ const DetailPage = () => {
                 congestionMessage={congestionMessage}
               />
             )}
+
+            {placeInfo && placeId && <CongestionTrendSection areaCode={placeId} />}
 
             {placeInfo && placeId && <AiInsightCard areaCode={placeId} />}
 

--- a/src/types/congestion.ts
+++ b/src/types/congestion.ts
@@ -79,3 +79,21 @@ export interface AireportResponse {
   analysisMessage: string;
   populationTime: string;
 }
+
+// 시간대별·요일별 평균 추이 응답 (시간별: key=0~23 / 요일별: key=1=일~7=토)
+export interface CongestionTrendPoint {
+  key: number;
+  label: string;
+  congestionLevel: string; // 한국어 dominant level
+  avgMinPeople: number;
+  avgMaxPeople: number;
+  dataCount: number;
+}
+
+export interface CongestionTrendResponse {
+  areaCode: string;
+  areaName: string;
+  data: CongestionTrendPoint[];
+}
+
+export type CongestionTrendKind = 'hourly' | 'daily';


### PR DESCRIPTION
## 배경

DetailPage(`/place/:areaCode`)는 그 장소의 현재 혼잡도와 AI 리포트(장소별 혼잡 원인을 풀어주는 분석 메시지)만 보여줘서, 사용자가 "지금 가도 되는지" 판단할 때 그 장소가 평소 어떤 패턴인지 알 길이 없는 상태였음. 백엔드가 시간대별·요일별 평균 추이 API를 이미 제공하고 있어 프론트만 연결.

## 백엔드 API

- `GET /api/congestion/analysis/hourly/{areaCode}?days=N` → 시간대(0시부터 23시) 평균 추이, 24개 행
- `GET /api/congestion/analysis/daily/{areaCode}?days=N` → 요일(1=일, 7=토) 평균 추이, 7개 행
- 각 행: `key`, `label`, `congestionLevel`(dominant 1개), `avgMinPeople`, `avgMaxPeople`, `dataCount`

## UI 결정

시간대와 요일별 두 관점을 토글로 통합하고 default는 시간대별. 외출 중 "지금 가도 되나" 시나리오와 "주말에 가야하나" 같은 미리 계획 시나리오 모두 커버하기 위함.

차트는 막대로 통일. 시간대(24개), 요일(7개) 모두 카테고리형이라 자연스럽고 같은 컴포넌트를 두 데이터에 재사용. 색상은 congestionLevel별로 매핑하고, 자세한 정보(avgMinPeople부터 avgMaxPeople 범위)는 툴팁에 노출. 툴팁 안 congestionLevel 텍스트 옆에 막대와 같은 색상의 dot을 함께 표시해 시각 일관성 확보. 호버 시 빈 칸이 회색으로 바뀌던 cursor 영역은 제거.

현재 시각이나 요일에 해당하는 막대는 검은 stroke 없이 다른 막대 fillOpacity 0.5로 흐리게 두고 현재 막대 위에 "지금" 라벨과 작은 dot으로 세련되게 강조. 요일 순서는 백엔드가 1=일부터 7=토로 주는 것을 한국 사용자에게 자연스러운 월부터 일 순서로 프론트에서 재배열해 평일은 왼쪽, 주말은 오른쪽 끝에 모이게 함.

section 제목 하단에 "최근 7일 측정 데이터 평균" 한 줄 안내를 두어 사용자가 그래프 의미를 즉시 이해하게 함.

## 차트 라이브러리

recharts, visx, Chart.js, 직접 SVG, Nivo, ECharts 6개 후보를 번들 사이즈, 러닝 커브, React 친화, 접근성, Tailwind 결합, 작업 속도 6축으로 비교한 끝에 recharts 선정. React 친화 선언적 API와 낮은 러닝 커브, SVG 기반 접근성이 D-Day 시간 ROI와 단번에 차트 단순도(막대 + 토글)에 가장 정합.

채택 안 한 대안:
- **visx**: 자유도 좋지만 저수준이라 막대·축·툴팁 다 직접 구현 필요 → D-Day 시간 ROI X
- **Chart.js**: 가볍지만 Canvas 기반이라 접근성·Tailwind 결합 어색, custom 스타일링 부담
- **직접 SVG**: 의존성 0 매력적이지만 스케일·축·반응형 다 직접 구현 → 시간 부족
- **Nivo/ECharts**: 번들 더 크고 단번에 차트 단순도에 over-spec

Recharts 3.x에서 children `Cell`이 deprecated되어, 데이터 객체에 `fill`과 `fillOpacity`를 포함해 `Bar`가 자동 적용하는 v4 호환 패턴으로 구현.

## 데이터 fetching

useHourlyTrend와 useDailyTrend hook을 이전 PR #62에서 도입한 TanStack Query 위에 처음부터 구축. queryKey는 `['congestion-trend', kind, areaCode, days, todayKst]`로 잡고, todayKst에는 KST 기준 오늘 날짜 문자열(예: `2026-06-07`) 포함.

백엔드 응답이 지난 7일 평균이라 같은 날 안에는 새 fetch를 해도 평균이 거의 안 변하지만, 자정이 지나면 7일 윈도가 한 칸 밀려서 의미 있는 갱신 발생. todayKst를 queryKey에 넣으면 같은 날 안에는 캐시 hit으로 응답을 그대로 쓰고, 자정 후 첫 진입에서는 새 queryKey가 만들어져 자동으로 새 fetch 트리거. staleTime과 gcTime은 모두 24시간, retry는 404 제외.

CongestionTrendSection에서 useHourlyTrend와 useDailyTrend 두 hook을 동시에 호출해 양쪽 캐시를 채워두는데, 토글 전환 시 즉시 캐시 hit으로 표시하기 위한 UX 우선 선택. 응답이 작아 추가 트래픽 부담은 낮다고 봄.

## 시간 흐름 강조

CongestionTrendSection에 1분 단위 setInterval tick을 두어 highlightKey를 강제 재계산. 사용자가 페이지에 머무는 동안 시간이 흘러도 "지금" 강조가 따라가게 함.

## 관련 이슈
Closes #63
