### PR TITLE
feat: 모바일 Hotspots 바텀시트 스와이프 닫기 지원

### DIFF
--- a/src/components/congestion/RankingBottomSheet.tsx
+++ b/src/components/congestion/RankingBottomSheet.tsx
@@ -120,7 +120,10 @@ const Section = ({
 const RankingBottomSheet = ({ busiest, relaxed, loading, error }: Props) => {
   const navigate = useNavigate();
   const [open, setOpen] = useState(false);
-  const { dragY, touchHandlers } = useSwipeDown({ onDismiss: () => setOpen(false) });
+  const { dragY, touchHandlers } = useSwipeDown({
+    onDismiss: () => setOpen(false),
+    dismissOnTap: false,
+  });
 
   // 시트가 열려있을 때만 Escape 키 리스너 — 닫혔을 때는 등록도 안 해 불필요한 비용 회피.
   useEffect(() => {
@@ -164,7 +167,8 @@ const RankingBottomSheet = ({ busiest, relaxed, loading, error }: Props) => {
         role="dialog"
         aria-label="혼잡도 랭킹"
         aria-hidden={!open}
-        className={`fixed inset-x-0 bottom-0 z-20 bg-white rounded-t-[28px] shadow-[0_-8px_32px_rgba(15,23,42,0.1)] ring-1 ring-slate-900/5 ${
+        {...touchHandlers}
+        className={`fixed inset-x-0 bottom-0 z-20 bg-white rounded-t-[28px] shadow-[0_-8px_32px_rgba(15,23,42,0.1)] ring-1 ring-slate-900/5 touch-none ${
           dragging ? '' : 'transition-transform duration-300 ease-out'
         }`}
         style={{
@@ -173,15 +177,9 @@ const RankingBottomSheet = ({ busiest, relaxed, loading, error }: Props) => {
       >
         <button
           type="button"
-          {...touchHandlers}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-              e.preventDefault();
-              setOpen(false);
-            }
-          }}
+          onClick={() => setOpen(false)}
           aria-label="시트 닫기"
-          className="cursor-pointer w-full flex justify-center pt-3 pb-2 touch-none"
+          className="cursor-pointer w-full flex justify-center pt-3 pb-2"
         >
           <div className="w-9 h-1 bg-slate-200 rounded-full" />
         </button>

--- a/src/components/congestion/RankingBottomSheet.tsx
+++ b/src/components/congestion/RankingBottomSheet.tsx
@@ -179,6 +179,7 @@ const RankingBottomSheet = ({ busiest, relaxed, loading, error }: Props) => {
           type="button"
           onClick={() => setOpen(false)}
           aria-label="시트 닫기"
+          data-swipe-allow
           className="cursor-pointer w-full flex justify-center pt-3 pb-2"
         >
           <div className="w-9 h-1 bg-slate-200 rounded-full" />

--- a/src/hooks/useSwipeDown.ts
+++ b/src/hooks/useSwipeDown.ts
@@ -4,17 +4,29 @@ interface Options {
   threshold?: number;
   // false면 가벼운 탭은 닫기로 처리하지 않음. 시트 본체 전체에 핸들러를 붙일 때 본문 탭이 닫기로 오판되는 걸 방지.
   dismissOnTap?: boolean;
+  // 이 거리(px)를 손가락이 넘기 전까지는 드래그를 시작하지 않음. 미세 떨림으로 시트가 출렁이고
+  // 자식 버튼 클릭이 취소되는 걸 막기 위한 dead zone. 시트 본체 전체에 핸들러를 붙일 때 의미가 큼.
+  activationDistance?: number;
   onDismiss: () => void;
 }
 
 const TAP_SLOP = 5;
+// data-swipe-allow가 붙은 인터랙티브 요소(예: 핸들 바)는 스와이프 시작점을 무시하지 않음.
+const INTERACTIVE_SELECTOR =
+  'button:not([data-swipe-allow]), a:not([data-swipe-allow]), [role="button"]:not([data-swipe-allow]), input, textarea, select';
 
 // state와 ref를 같이 들고 있는 이유: 빠른 스와이프에서 touchmove → touchend가 React
 // 리렌더 사이에 일어나면 state 기반 closure는 stale 값을 보게 됨. ref로 항상 최신 값 읽음.
-export const useSwipeDown = ({ threshold = 80, dismissOnTap = true, onDismiss }: Options) => {
+export const useSwipeDown = ({
+  threshold = 80,
+  dismissOnTap = true,
+  activationDistance = 8,
+  onDismiss,
+}: Options) => {
   const [dragY, setDragY] = useState(0);
   const dragYRef = useRef(0);
   const startYRef = useRef<number | null>(null);
+  const activatedRef = useRef(false);
 
   const updateDragY = (value: number) => {
     dragYRef.current = value;
@@ -23,23 +35,33 @@ export const useSwipeDown = ({ threshold = 80, dismissOnTap = true, onDismiss }:
 
   const touchHandlers = {
     onTouchStart: (e: React.TouchEvent) => {
+      // 인터랙티브 자식 위에서 시작한 터치는 무시 — 버튼 탭 의도를 드래그로 오인하지 않기 위해.
+      const target = e.target as Element | null;
+      if (target && target.closest(INTERACTIVE_SELECTOR)) return;
       startYRef.current = e.touches[0].clientY;
+      activatedRef.current = false;
     },
     onTouchMove: (e: React.TouchEvent) => {
       if (startYRef.current == null) return;
       const dy = e.touches[0].clientY - startYRef.current;
-      updateDragY(Math.max(0, dy));
+      if (!activatedRef.current) {
+        if (dy <= activationDistance) return;
+        activatedRef.current = true;
+      }
+      // 활성화 직후 시트가 activationDistance만큼 점프하지 않도록 빼주고 따라옴.
+      updateDragY(Math.max(0, dy - activationDistance));
     },
     onTouchEnd: () => {
       // touchstart 없이 touchend만 들어오는 엣지(멀티터치 간섭 등)에서 dragYRef=0이
       // tap으로 오판돼 의도치 않게 onDismiss가 호출되는 것 방지.
       if (startYRef.current == null) return;
       const movement = dragYRef.current;
-      const isTap = movement < TAP_SLOP;
+      const isTap = !activatedRef.current && movement < TAP_SLOP;
       const passedThreshold = movement > threshold;
       if ((dismissOnTap && isTap) || passedThreshold) onDismiss();
       updateDragY(0);
       startYRef.current = null;
+      activatedRef.current = false;
     },
   };
 

--- a/src/hooks/useSwipeDown.ts
+++ b/src/hooks/useSwipeDown.ts
@@ -2,21 +2,16 @@ import { useRef, useState } from 'react';
 
 interface Options {
   threshold?: number;
+  // false면 가벼운 탭은 닫기로 처리하지 않음. 시트 본체 전체에 핸들러를 붙일 때 본문 탭이 닫기로 오판되는 걸 방지.
+  dismissOnTap?: boolean;
   onDismiss: () => void;
 }
 
 const TAP_SLOP = 5;
 
-// 바텀시트 등에서 "아래로 끌어 닫기" 제스처를 처리.
-// - dragY: 현재 드래그 오프셋(px). 호출 측이 transform에 반영하면 손가락을 따라옴
-// - 손가락이 시작점보다 위로 가도 0으로 클램프해 시트가 시작 위치 위로 솟지 않게 함
-// - touchEnd 시 이동량이 TAP_SLOP 미만이면 탭으로 판정해 onDismiss
-// - 이동량이 threshold를 넘으면 드래그-닫기로 onDismiss
-// - 그 사이(부분 드래그)면 0으로 스냅백
-//
 // state와 ref를 같이 들고 있는 이유: 빠른 스와이프에서 touchmove → touchend가 React
 // 리렌더 사이에 일어나면 state 기반 closure는 stale 값을 보게 됨. ref로 항상 최신 값 읽음.
-export const useSwipeDown = ({ threshold = 80, onDismiss }: Options) => {
+export const useSwipeDown = ({ threshold = 80, dismissOnTap = true, onDismiss }: Options) => {
   const [dragY, setDragY] = useState(0);
   const dragYRef = useRef(0);
   const startYRef = useRef<number | null>(null);
@@ -42,7 +37,7 @@ export const useSwipeDown = ({ threshold = 80, onDismiss }: Options) => {
       const movement = dragYRef.current;
       const isTap = movement < TAP_SLOP;
       const passedThreshold = movement > threshold;
-      if (isTap || passedThreshold) onDismiss();
+      if ((dismissOnTap && isTap) || passedThreshold) onDismiss();
       updateDragY(0);
       startYRef.current = null;
     },


### PR DESCRIPTION
## 관련 이슈
Closes #67

사용자 피드백에서 모바일 뷰의 랭킹 바텀시트를 아래로 스크롤해서 닫을 수 없어 불편하다는 의견이 있었습니다.

기존에는 핸들 바 영역에서만 스와이프 다운이 인식돼서 시트 본문을 잡고 끌어내려도 닫히지 않았습니다. 이를 해결하기 위해 touchHandlers를 시트 컨테이너 전체로 이동해 어디를 잡든 스와이프로 닫히게 했고, 본문 탭이 닫기로 잘못 인식되는 걸 막기 위해 useSwipeDown에 dismissOnTap 옵션을 추가했습니다.
