### PR TITLE
feat: AI 혼잡 원인 리포트를 붐빔(CROWDED) 상태에서만 노출

### DIFF
--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -89,7 +89,9 @@ const DetailPage = () => {
 
             {placeInfo && placeId && <CongestionTrendSection areaCode={placeId} />}
 
-            {placeInfo && placeId && <AiInsightCard areaCode={placeId} />}
+            {placeInfo && placeId && congestionLevel === 'CROWDED' && (
+              <AiInsightCard areaCode={placeId} />
+            )}
 
             {placeInfo && (
               <CultureEventsSection


### PR DESCRIPTION
## 관련 이슈

Closes #72

DetailPage의 'AI가 본 혼잡 원인' 카드는 혼잡도가 가장 높은 붐빔(CROWDED) 단계에서만 의미 있는 분석이 제공되는데, 그 외 단계에서는 섹션 헤더와 "혼잡한 시점에 AI 분석이 생성돼요" placeholder가 그대로 노출돼 정보 밀도가 떨어졌습니다.

CROWDED일 때만 AiInsightCard를 렌더하도록 조건을 좁혀, 그 외 단계에서는 섹션 자체가 마운트되지 않도록 했습니다. AiInsightCard 내부 로직은 건드리지 않았고, 컴포넌트가 마운트되지 않는 동안에는 useAiReport의 query도 enabled되지 않아 불필요한 fetch도 함께 사라지도록 했습니다.
