### PR TITLE
feat: 모바일에서 혼잡할 때 대체지역 섹션을 행사정보 위로 이동

### DIFF
--- a/src/components/detail/AlternativePlacesSidebar.tsx
+++ b/src/components/detail/AlternativePlacesSidebar.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { CaretRightIcon } from '@phosphor-icons/react';
-import { useAlternativeLocations } from '../../hooks/useAlternativeLocations';
+import type { AlternativeLocationsState } from '../../hooks/useAlternativeLocations';
 import { LOCATION_MAP } from '../../data/locations';
 import { CATEGORY_NAMES } from '../../data/categories';
 import { CONGESTION_COLORS, CONGESTION_LABELS, CONGESTION_LEVEL_MAP } from '../../types/congestion';
@@ -8,7 +8,7 @@ import type { AlternativeLocation } from '../../types/map';
 import SectionHeader from './SectionHeader';
 
 interface Props {
-  areaCode: string;
+  state: AlternativeLocationsState;
 }
 
 const Header = () => (
@@ -64,9 +64,8 @@ const Item = ({
   );
 };
 
-const AlternativePlacesSidebar = ({ areaCode }: Props) => {
+const AlternativePlacesSidebar = ({ state }: Props) => {
   const navigate = useNavigate();
-  const state = useAlternativeLocations(areaCode);
 
   return (
     <aside className="lg:w-72 shrink-0">

--- a/src/hooks/useAlternativeLocations.ts
+++ b/src/hooks/useAlternativeLocations.ts
@@ -8,14 +8,14 @@ import type { AlternativeLocation } from '../types/map';
 // 응답 스키마 보강(populationTime 추가)은 별도 백엔드 이슈로 분리.
 const POLL_INTERVAL = 5 * 60 * 1000;
 
-type State =
+export type AlternativeLocationsState =
   | { status: 'loading' }
   | { status: 'success'; data: AlternativeLocation[] } // 보장: data.length > 0
   | { status: 'empty' } // 추천 결과 없음 (빈 배열)
   | { status: 'error' };
 
 export const useAlternativeLocations = (areaCode: string | null) => {
-  const [state, setState] = useState<State>({ status: 'loading' });
+  const [state, setState] = useState<AlternativeLocationsState>({ status: 'loading' });
   const hasLoadedRef = useRef<boolean>(false);
 
   useEffect(() => {

--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -8,6 +8,7 @@ import CultureEventsSection from '../components/detail/CultureEventsSection';
 import LocationSection from '../components/detail/LocationSection';
 import AlternativePlacesSidebar from '../components/detail/AlternativePlacesSidebar';
 import CongestionTrendSection from '../components/detail/CongestionTrendSection';
+import { useAlternativeLocations } from '../hooks/useAlternativeLocations';
 import { fetchCongestionByAreaCode } from '../api/congestionApi';
 import { LOCATION_MAP } from '../data/locations';
 import { CONGESTION_COLORS, CONGESTION_LEVEL_MAP } from '../types/congestion';
@@ -49,6 +50,9 @@ const DetailPage = () => {
 
   const isUnavailable = !loading && ((!marker && !data) || !placeInfo);
   const isReady = !loading && (marker || data) && placeInfo && congestionLevel;
+  const isCongested = congestionLevel === 'BUSY' || congestionLevel === 'CROWDED';
+  const showAlternatives = !!placeId && !!congestionLevel && congestionLevel !== 'QUIET';
+  const alternativesState = useAlternativeLocations(showAlternatives ? placeId : null);
 
   return (
     <div className="flex flex-col w-full min-h-dvh bg-slate-50">
@@ -93,6 +97,12 @@ const DetailPage = () => {
               <AiInsightCard areaCode={placeId} />
             )}
 
+            {placeInfo && showAlternatives && isCongested && (
+              <div className="lg:hidden">
+                <AlternativePlacesSidebar state={alternativesState} />
+              </div>
+            )}
+
             {placeInfo && (
               <CultureEventsSection
                 latitude={placeInfo.latitude}
@@ -109,8 +119,10 @@ const DetailPage = () => {
             )}
           </div>
 
-          {placeInfo && placeId && congestionLevel !== 'QUIET' && (
-            <AlternativePlacesSidebar areaCode={placeId} />
+          {placeInfo && showAlternatives && (
+            <div className={isCongested ? 'hidden lg:block' : ''}>
+              <AlternativePlacesSidebar state={alternativesState} />
+            </div>
           )}
         </div>
       </div>

--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -51,7 +51,7 @@ const DetailPage = () => {
   const isUnavailable = !loading && ((!marker && !data) || !placeInfo);
   const isReady = !loading && (marker || data) && placeInfo && congestionLevel;
   const isCongested = congestionLevel === 'BUSY' || congestionLevel === 'CROWDED';
-  const showAlternatives = !!placeId && !!congestionLevel && congestionLevel !== 'QUIET';
+  const showAlternatives = !!placeId && congestionLevel !== 'QUIET';
   const alternativesState = useAlternativeLocations(showAlternatives ? placeId : null);
 
   return (
@@ -120,7 +120,7 @@ const DetailPage = () => {
           </div>
 
           {placeInfo && showAlternatives && (
-            <div className={isCongested ? 'hidden lg:block' : ''}>
+            <div className={isCongested || loading ? 'hidden lg:block' : ''}>
               <AlternativePlacesSidebar state={alternativesState} />
             </div>
           )}


### PR DESCRIPTION
## 관련 이슈

Closes #71

DetailPage에서 약간 붐빔(BUSY)·붐빔(CROWDED) 단계일 때 모바일 사용자가 행사/문화정보보다 대체지역을 먼저 볼 수 있도록 표시 순서를 조정했습니다. 모바일에선 대체지역 섹션이 행사정보 위로 올라오고, 데스크탑(lg 이상)에선 기존의 오른쪽 사이드바 위치를 그대로 유지합니다. 보통(MODERATE) 단계에서는 노출되더라도 위치 변경 없이 기존 그대로 둡니다.

두 위치(모바일 인라인, 데스크탑 사이드바)가 같은 데이터를 보여줘야 해서, AlternativePlacesSidebar 내부에서 호출하던 useAlternativeLocations를 DetailPage로 끌어올려 한 번만 호출하고 state를 prop으로 전달하도록 정리했습니다. 덕분에 두 인스턴스가 마운트되어 있어도 fetch와 polling은 한 번만 일어납니다.
